### PR TITLE
feat(web): styled paradigm tables for nouns, verbs, and adjectives — replaces flat form list

### DIFF
--- a/packages/web/src/components/paradigm/AdjTable.tsx
+++ b/packages/web/src/components/paradigm/AdjTable.tsx
@@ -1,0 +1,93 @@
+import { For, Show } from 'solid-js'
+import { css } from '../../../styled-system/css'
+import {
+  parseNKJP, CASE_ORDER, CASE_LABELS, DEGREE_LABELS,
+  type MorphFormData, type NKJPCase, type NKJPNumber, type NKJPDegree,
+} from '../../utils/nkjp'
+
+const tableWrapper = css({ overflowX: 'auto', w: 'full', mb: '6' })
+const table = css({ borderCollapse: 'collapse', w: 'full' })
+const colHeader = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', color: 'fg.muted', pb: '2', px: '3', textAlign: 'left' })
+const rowLabel = css({ fontSize: 'sm', color: 'fg.muted', fontWeight: 'medium', pr: '4', py: '1.5', whiteSpace: 'nowrap' })
+const cell = css({ fontFamily: 'mono', fontSize: 'sm', py: '1.5', px: '3' })
+const emptyCell = css({ color: 'fg.subtle' })
+const rowBorder = css({ borderBottom: '1px solid', borderColor: 'border' })
+const sectionHeading = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', letterSpacing: 'wide', color: 'fg.muted', mb: '3', mt: '6' })
+
+interface Column {
+  label: string
+  number: NKJPNumber
+  genders: string[]
+}
+
+const COLUMNS: Column[] = [
+  { label: 'Sg Masc', number: 'sg', genders: ['m1', 'm2', 'm3'] },
+  { label: 'Sg Fem', number: 'sg', genders: ['f'] },
+  { label: 'Sg Neut', number: 'sg', genders: ['n'] },
+  { label: 'Pl M-Pers', number: 'pl', genders: ['m1'] },
+  { label: 'Pl Other', number: 'pl', genders: ['m2', 'm3', 'f', 'n'] },
+]
+
+export function AdjTable(props: { forms: MorphFormData[] }) {
+  const parsed = () => props.forms.map(f => ({ ...parseNKJP(f.tag), orth: f.orth }))
+
+  const degrees = (): NKJPDegree[] => {
+    const found = new Set<NKJPDegree>()
+    for (const p of parsed()) {
+      if (p.pos === 'adj' && p.degree) found.add(p.degree)
+    }
+    return (['pos', 'com', 'sup'] as NKJPDegree[]).filter(d => found.has(d))
+  }
+
+  const findOrth = (degree: NKJPDegree, cas: NKJPCase, col: Column): string | undefined => {
+    for (const p of parsed()) {
+      if (p.pos !== 'adj') continue
+      if (p.degree !== degree) continue
+      if (!p.number?.includes(col.number)) continue
+      if (!p.cases?.includes(cas)) continue
+      if (!p.genders?.some(g => col.genders.includes(g))) continue
+      return p.orth
+    }
+    return undefined
+  }
+
+  return (
+    <div>
+      <For each={degrees()}>
+        {(degree) => (
+          <>
+            <div class={sectionHeading}>{DEGREE_LABELS[degree]}</div>
+            <div class={tableWrapper}>
+              <table class={table}>
+                <thead>
+                  <tr>
+                    <th class={colHeader} />
+                    <For each={COLUMNS}>
+                      {(col) => <th class={colHeader}>{col.label}</th>}
+                    </For>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={CASE_ORDER}>
+                    {(cas) => (
+                      <tr class={rowBorder}>
+                        <td class={rowLabel}>{CASE_LABELS[cas]}</td>
+                        <For each={COLUMNS}>
+                          {(col) => (
+                            <td class={cell}>
+                              {findOrth(degree, cas, col) ?? <span class={emptyCell}>{'\u2014'}</span>}
+                            </td>
+                          )}
+                        </For>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </For>
+    </div>
+  )
+}

--- a/packages/web/src/components/paradigm/FlatFormTable.tsx
+++ b/packages/web/src/components/paradigm/FlatFormTable.tsx
@@ -1,0 +1,43 @@
+import { For, createMemo } from 'solid-js'
+import { css } from '../../../styled-system/css'
+import type { MorphFormData } from '../../utils/nkjp'
+
+const tableWrapper = css({ overflowX: 'auto', w: 'full', mb: '6' })
+const table = css({ borderCollapse: 'collapse', w: 'full' })
+const colHeader = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', color: 'fg.muted', pb: '2', px: '3', textAlign: 'left' })
+const cell = css({ fontFamily: 'mono', fontSize: 'sm', py: '1.5', px: '3' })
+const tagCell = css({ fontSize: 'xs', py: '1.5', px: '3' })
+const rowBorder = css({ borderBottom: '1px solid', borderColor: 'border' })
+
+export function FlatFormTable(props: { forms: MorphFormData[] }) {
+  const sorted = createMemo(() =>
+    [...props.forms].sort((a, b) => a.tag.localeCompare(b.tag))
+  )
+
+  return (
+    <div class={tableWrapper}>
+      <table class={table}>
+        <thead>
+          <tr>
+            <th class={colHeader}>Form</th>
+            <th class={colHeader}>Tag</th>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={sorted()}>
+            {(form) => (
+              <tr class={rowBorder}>
+                <td class={cell}>{form.orth}</td>
+                <td class={tagCell}>
+                  <code class={css({ fontSize: 'xs', bg: 'bg.muted', px: '2', py: '0.5', borderRadius: 'sm' })}>
+                    {form.tag}
+                  </code>
+                </td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/web/src/components/paradigm/NounTable.tsx
+++ b/packages/web/src/components/paradigm/NounTable.tsx
@@ -1,0 +1,62 @@
+import { For } from 'solid-js'
+import { css } from '../../../styled-system/css'
+import {
+  parseNKJP, CASE_ORDER, CASE_LABELS,
+  type MorphFormData, type NKJPCase, type NKJPNumber,
+} from '../../utils/nkjp'
+
+const tableWrapper = css({ overflowX: 'auto', w: 'full', mb: '6' })
+const table = css({ borderCollapse: 'collapse', w: 'full' })
+const colHeader = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', color: 'fg.muted', pb: '2', px: '3', textAlign: 'left' })
+const rowLabel = css({ fontSize: 'sm', color: 'fg.muted', fontWeight: 'medium', pr: '4', py: '1.5', whiteSpace: 'nowrap' })
+const cell = css({ fontFamily: 'mono', fontSize: 'sm', py: '1.5', px: '3' })
+const emptyCell = css({ color: 'fg.subtle' })
+const rowBorder = css({ borderBottom: '1px solid', borderColor: 'border' })
+
+export function NounTable(props: { forms: MorphFormData[] }) {
+  const lookup = () => {
+    const map = new Map<NKJPCase, Map<NKJPNumber, string>>()
+    for (const cas of CASE_ORDER) {
+      map.set(cas, new Map())
+    }
+    for (const form of props.forms) {
+      const parsed = parseNKJP(form.tag)
+      if (parsed.pos !== 'subst') continue
+      for (const num of parsed.number ?? []) {
+        for (const cas of parsed.cases ?? []) {
+          map.get(cas)?.set(num, form.orth)
+        }
+      }
+    }
+    return map
+  }
+
+  return (
+    <div class={tableWrapper}>
+      <table class={table}>
+        <thead>
+          <tr>
+            <th class={colHeader} />
+            <th class={colHeader}>Singular</th>
+            <th class={colHeader}>Plural</th>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={CASE_ORDER}>
+            {(cas) => (
+              <tr class={rowBorder}>
+                <td class={rowLabel}>{CASE_LABELS[cas]}</td>
+                <td class={cell}>
+                  {lookup().get(cas)?.get('sg') ?? <span class={emptyCell}>{'\u2014'}</span>}
+                </td>
+                <td class={cell}>
+                  {lookup().get(cas)?.get('pl') ?? <span class={emptyCell}>{'\u2014'}</span>}
+                </td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/web/src/components/paradigm/VerbTable.tsx
+++ b/packages/web/src/components/paradigm/VerbTable.tsx
@@ -1,0 +1,252 @@
+import { For, Show } from 'solid-js'
+import { css } from '../../../styled-system/css'
+import {
+  parseNKJP, PERSON_ORDER, PERSON_LABELS,
+  type MorphFormData, type ParsedNKJP, type NKJPNumber, type NKJPPerson,
+} from '../../utils/nkjp'
+
+const tableWrapper = css({ overflowX: 'auto', w: 'full', mb: '6' })
+const table = css({ borderCollapse: 'collapse', w: 'full' })
+const colHeader = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', color: 'fg.muted', pb: '2', px: '3', textAlign: 'left' })
+const rowLabel = css({ fontSize: 'sm', color: 'fg.muted', fontWeight: 'medium', pr: '4', py: '1.5', whiteSpace: 'nowrap' })
+const cell = css({ fontFamily: 'mono', fontSize: 'sm', py: '1.5', px: '3' })
+const emptyCell = css({ color: 'fg.subtle' })
+const rowBorder = css({ borderBottom: '1px solid', borderColor: 'border' })
+const sectionHeading = css({ fontSize: 'xs', fontWeight: 'semibold', textTransform: 'uppercase', letterSpacing: 'wide', color: 'fg.muted', mb: '3', mt: '6' })
+const inlineLabel = css({ fontSize: 'sm', color: 'fg.muted', fontWeight: 'medium', mr: '3' })
+
+function arraysIntersect(a: string[] | undefined, b: string[]): boolean {
+  if (!a) return false
+  return a.some(v => b.includes(v))
+}
+
+export function VerbTable(props: { forms: MorphFormData[] }) {
+  const parsed = () => props.forms.map(f => ({ ...parseNKJP(f.tag), orth: f.orth }))
+
+  const findOrth = (criteria: Partial<ParsedNKJP> & { matchGenders?: string[] }): string | undefined => {
+    for (const p of parsed()) {
+      if (criteria.pos && p.pos !== criteria.pos) continue
+      if (criteria.number && !arraysIntersect(p.number, criteria.number)) continue
+      if (criteria.person && p.person !== criteria.person) continue
+      if (criteria.aspect && p.aspect !== criteria.aspect) continue
+      if (criteria.matchGenders && !arraysIntersect(p.genders, criteria.matchGenders)) continue
+      return p.orth
+    }
+    return undefined
+  }
+
+  const hasPos = (pos: string) => parsed().some(p => p.pos === pos)
+
+  const infForm = () => findOrth({ pos: 'inf' })
+  const hasFin = () => hasPos('fin')
+  const hasPraet = () => hasPos('praet')
+  const hasImpt = () => hasPos('impt') || hasPos('imps')
+  const hasPcon = () => hasPos('pcon') || hasPos('pacta')
+  const hasGer = () => hasPos('ger')
+  const hasPact = () => hasPos('pact')
+  const hasPpas = () => hasPos('ppas')
+
+  return (
+    <div>
+      {/* Infinitive */}
+      <Show when={infForm()}>
+        {(form) => (
+          <>
+            <div class={sectionHeading}>Infinitive</div>
+            <div class={css({ fontFamily: 'mono', fontSize: 'sm', mb: '2', pl: '3' })}>{form()}</div>
+          </>
+        )}
+      </Show>
+
+      {/* Present tense */}
+      <Show when={hasFin()}>
+        <div class={sectionHeading}>Present</div>
+        <div class={tableWrapper}>
+          <table class={table}>
+            <thead>
+              <tr>
+                <th class={colHeader} />
+                <th class={colHeader}>Singular</th>
+                <th class={colHeader}>Plural</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={PERSON_ORDER}>
+                {(person) => (
+                  <tr class={rowBorder}>
+                    <td class={rowLabel}>{PERSON_LABELS[person]}</td>
+                    <td class={cell}>
+                      {findOrth({ pos: 'fin', number: ['sg'], person }) ?? <span class={emptyCell}>{'\u2014'}</span>}
+                    </td>
+                    <td class={cell}>
+                      {findOrth({ pos: 'fin', number: ['pl'], person }) ?? <span class={emptyCell}>{'\u2014'}</span>}
+                    </td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+
+      {/* Past tense */}
+      <Show when={hasPraet()}>
+        <div class={sectionHeading}>Past</div>
+        <div class={tableWrapper}>
+          <table class={table}>
+            <thead>
+              <tr>
+                <th class={colHeader} />
+                <th class={colHeader}>Form</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={[
+                { label: 'Sg Masculine', criteria: { pos: 'praet', number: ['sg'] as NKJPNumber[], matchGenders: ['m1', 'm2', 'm3'] } },
+                { label: 'Sg Feminine', criteria: { pos: 'praet', number: ['sg'] as NKJPNumber[], matchGenders: ['f'] } },
+                { label: 'Sg Neuter', criteria: { pos: 'praet', number: ['sg'] as NKJPNumber[], matchGenders: ['n'] } },
+                { label: 'Pl M-Personal', criteria: { pos: 'praet', number: ['pl'] as NKJPNumber[], matchGenders: ['m1'] } },
+                { label: 'Pl Non-M-Pers.', criteria: { pos: 'praet', number: ['pl'] as NKJPNumber[], matchGenders: ['m2', 'm3', 'f', 'n'] } },
+              ]}>
+                {(row) => (
+                  <tr class={rowBorder}>
+                    <td class={rowLabel}>{row.label}</td>
+                    <td class={cell}>
+                      {findOrth(row.criteria) ?? <span class={emptyCell}>{'\u2014'}</span>}
+                    </td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+
+      {/* Imperative */}
+      <Show when={hasImpt()}>
+        <div class={sectionHeading}>Imperative</div>
+        <div class={tableWrapper}>
+          <table class={table}>
+            <thead>
+              <tr>
+                <th class={colHeader} />
+                <th class={colHeader}>Form</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={[
+                { label: '2nd Sg', criteria: { pos: 'impt', number: ['sg'] as NKJPNumber[], person: 'sec' as NKJPPerson } },
+                { label: '1st Pl', criteria: { pos: 'impt', number: ['pl'] as NKJPNumber[], person: 'pri' as NKJPPerson } },
+                { label: '2nd Pl', criteria: { pos: 'impt', number: ['pl'] as NKJPNumber[], person: 'sec' as NKJPPerson } },
+              ]}>
+                {(row) => (
+                  <tr class={rowBorder}>
+                    <td class={rowLabel}>{row.label}</td>
+                    <td class={cell}>
+                      {findOrth(row.criteria) ?? <span class={emptyCell}>{'\u2014'}</span>}
+                    </td>
+                  </tr>
+                )}
+              </For>
+              <Show when={findOrth({ pos: 'imps' })}>
+                {(form) => (
+                  <tr class={rowBorder}>
+                    <td class={rowLabel}>Impersonal</td>
+                    <td class={cell}>{form()}</td>
+                  </tr>
+                )}
+              </Show>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+
+      {/* Adverbial participle */}
+      <Show when={hasPcon()}>
+        <div class={sectionHeading}>Adverbial Participle</div>
+        <div class={css({ pl: '3', mb: '2' })}>
+          <Show when={findOrth({ pos: 'pcon' })}>
+            {(form) => (
+              <div class={css({ display: 'flex', alignItems: 'baseline', mb: '1' })}>
+                <span class={inlineLabel}>Contemp.</span>
+                <span class={css({ fontFamily: 'mono', fontSize: 'sm' })}>{form()}</span>
+              </div>
+            )}
+          </Show>
+          <Show when={findOrth({ pos: 'pacta' })}>
+            {(form) => (
+              <div class={css({ display: 'flex', alignItems: 'baseline', mb: '1' })}>
+                <span class={inlineLabel}>Anterior</span>
+                <span class={css({ fontFamily: 'mono', fontSize: 'sm' })}>{form()}</span>
+              </div>
+            )}
+          </Show>
+        </div>
+      </Show>
+
+      {/* Verbal noun */}
+      <Show when={hasGer()}>
+        <div class={sectionHeading}>Verbal Noun</div>
+        <div class={css({ pl: '3', mb: '2' })}>
+          <Show when={findOrth({ pos: 'ger', number: ['sg'], matchGenders: ['n'] })}>
+            {(form) => (
+              <span class={css({ fontFamily: 'mono', fontSize: 'sm' })}>{form()}</span>
+            )}
+          </Show>
+        </div>
+      </Show>
+
+      {/* Active participle */}
+      <Show when={hasPact()}>
+        <div class={sectionHeading}>Active Participle</div>
+        <div class={css({ display: 'flex', gap: '4', pl: '3', mb: '2', flexWrap: 'wrap' })}>
+          <For each={[
+            { label: 'M', genders: ['m1', 'm2', 'm3'] },
+            { label: 'F', genders: ['f'] },
+            { label: 'N', genders: ['n'] },
+          ]}>
+            {(col) => {
+              const form = () => findOrth({ pos: 'pact', number: ['sg'], matchGenders: col.genders })
+              return (
+                <Show when={form()}>
+                  {(f) => (
+                    <div class={css({ display: 'flex', alignItems: 'baseline' })}>
+                      <span class={inlineLabel}>{col.label}</span>
+                      <span class={css({ fontFamily: 'mono', fontSize: 'sm' })}>{f()}</span>
+                    </div>
+                  )}
+                </Show>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
+
+      {/* Passive participle */}
+      <Show when={hasPpas()}>
+        <div class={sectionHeading}>Passive Participle</div>
+        <div class={css({ display: 'flex', gap: '4', pl: '3', mb: '2', flexWrap: 'wrap' })}>
+          <For each={[
+            { label: 'M', genders: ['m1', 'm2', 'm3'] },
+            { label: 'F', genders: ['f'] },
+            { label: 'N', genders: ['n'] },
+          ]}>
+            {(col) => {
+              const form = () => findOrth({ pos: 'ppas', number: ['sg'], matchGenders: col.genders })
+              return (
+                <Show when={form()}>
+                  {(f) => (
+                    <div class={css({ display: 'flex', alignItems: 'baseline' })}>
+                      <span class={inlineLabel}>{col.label}</span>
+                      <span class={css({ fontFamily: 'mono', fontSize: 'sm' })}>{f()}</span>
+                    </div>
+                  )}
+                </Show>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/packages/web/src/routes/lemmas/[id].tsx
+++ b/packages/web/src/routes/lemmas/[id].tsx
@@ -1,4 +1,4 @@
-import { createResource, createMemo, For, Show, Suspense, ErrorBoundary } from 'solid-js'
+import { createResource, createSignal, Show, Suspense, ErrorBoundary, Switch, Match } from 'solid-js'
 import { useParams, useNavigate } from '@solidjs/router'
 import { css } from '../../../styled-system/css'
 import { api } from '../../api/client'
@@ -8,7 +8,10 @@ import { Spinner } from '../../components/Spinner'
 import { EmptyState } from '../../components/EmptyState'
 import { ErrorState } from '../../components/ErrorState'
 import { ConfirmDialog } from '../../components/ConfirmDialog'
-import { createSignal } from 'solid-js'
+import { NounTable } from '../../components/paradigm/NounTable'
+import { VerbTable } from '../../components/paradigm/VerbTable'
+import { AdjTable } from '../../components/paradigm/AdjTable'
+import { FlatFormTable } from '../../components/paradigm/FlatFormTable'
 
 export default function LemmaDetail() {
   const params = useParams<{ id: string }>()
@@ -20,12 +23,6 @@ export default function LemmaDetail() {
   const [showDelete, setShowDelete] = createSignal(false)
   const [deleting, setDeleting] = createSignal(false)
 
-  const sortedForms = createMemo(() => {
-    const data = forms()
-    if (!data) return []
-    return [...data].sort((a, b) => a.tag.localeCompare(b.tag))
-  })
-
   const handleDelete = async () => {
     setDeleting(true)
     try {
@@ -33,14 +30,6 @@ export default function LemmaDetail() {
       navigate('/lemmas')
     } finally {
       setDeleting(false)
-    }
-  }
-
-  const parseParsedTag = (json: string): Record<string, string> => {
-    try {
-      return JSON.parse(json)
-    } catch {
-      return {}
     }
   }
 
@@ -76,50 +65,21 @@ export default function LemmaDetail() {
 
                 <Suspense fallback={<Spinner />}>
                   <Show when={forms()}>
-                    {() => (
+                    {(fs) => (
                       <Show
-                        when={sortedForms().length > 0}
+                        when={fs().length > 0}
                         fallback={
                           <EmptyState
                             heading="No forms"
-                            description={data().source === 'manual' ? 'This lemma uses manual source — forms must be added manually.' : 'No morphological forms were generated.'}
+                            description={data().source === 'manual' ? 'This lemma uses manual source \u2014 forms must be added manually.' : 'No morphological forms were generated.'}
                           />
                         }
                       >
-                        <table class={css({ w: 'full', borderCollapse: 'collapse' })}>
-                          <thead>
-                            <tr class={css({ borderBottom: '2px solid', borderColor: 'border' })}>
-                              <th class={css({ textAlign: 'left', p: '3', fontSize: 'sm', fontWeight: 'semibold' })}>Form</th>
-                              <th class={css({ textAlign: 'left', p: '3', fontSize: 'sm', fontWeight: 'semibold' })}>Tag</th>
-                              <th class={css({ textAlign: 'left', p: '3', fontSize: 'sm', fontWeight: 'semibold' })}>Breakdown</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <For each={sortedForms()}>
-                              {(form) => (
-                                <tr class={css({ borderBottom: '1px solid', borderColor: 'border', _hover: { bg: 'bg.subtle' } })}>
-                                  <td class={css({ p: '3', fontFamily: 'monospace', fontWeight: 'medium' })}>
-                                    {form.orth}
-                                  </td>
-                                  <td class={css({ p: '3' })}>
-                                    <code class={css({ fontSize: 'xs', bg: 'bg.muted', px: '2', py: '0.5', borderRadius: 'sm' })}>
-                                      {form.tag}
-                                    </code>
-                                  </td>
-                                  <td class={css({ p: '3' })}>
-                                    <div class={css({ display: 'flex', gap: '1', flexWrap: 'wrap' })}>
-                                      <For each={Object.entries(parseParsedTag(form.parsedTag))}>
-                                        {([key, value]) => (
-                                          <Badge value={`${key}: ${value}`} />
-                                        )}
-                                      </For>
-                                    </div>
-                                  </td>
-                                </tr>
-                              )}
-                            </For>
-                          </tbody>
-                        </table>
+                        <Switch fallback={<FlatFormTable forms={fs()} />}>
+                          <Match when={data().pos === 'subst'}><NounTable forms={fs()} /></Match>
+                          <Match when={data().pos === 'verb'}><VerbTable forms={fs()} /></Match>
+                          <Match when={data().pos === 'adj'}><AdjTable forms={fs()} /></Match>
+                        </Switch>
                       </Show>
                     )}
                   </Show>

--- a/packages/web/src/utils/nkjp.ts
+++ b/packages/web/src/utils/nkjp.ts
@@ -1,0 +1,71 @@
+export type NKJPCase = 'nom' | 'gen' | 'dat' | 'acc' | 'inst' | 'loc' | 'voc'
+export type NKJPNumber = 'sg' | 'pl'
+export type NKJPGender = 'm1' | 'm2' | 'm3' | 'f' | 'n'
+export type NKJPPerson = 'pri' | 'sec' | 'ter'
+export type NKJPDegree = 'pos' | 'com' | 'sup'
+export type NKJPAspect = 'perf' | 'imperf'
+
+export interface ParsedNKJP {
+  pos: string
+  number?: NKJPNumber[]
+  cases?: NKJPCase[]
+  genders?: NKJPGender[]
+  person?: NKJPPerson
+  degree?: NKJPDegree
+  aspect?: NKJPAspect
+  negation?: 'aff' | 'neg'
+  raw: string
+}
+
+export function parseNKJP(tag: string): ParsedNKJP {
+  const parts = tag.split(':')
+  const pos = parts[0]!
+  const splitMulti = <T>(s?: string): T[] | undefined =>
+    s ? (s.split('.') as T[]) : undefined
+
+  const spread = <K extends string, V>(key: K, val: V | undefined): Record<K, V> | Record<string, never> =>
+    val !== undefined ? ({ [key]: val } as Record<K, V>) : ({} as Record<string, never>)
+
+  const base = { pos, raw: tag }
+
+  switch (pos) {
+    case 'subst':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), ...spread('cases', splitMulti<NKJPCase>(parts[2])), ...spread('genders', splitMulti<NKJPGender>(parts[3])) }
+    case 'adj':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), ...spread('cases', splitMulti<NKJPCase>(parts[2])), ...spread('genders', splitMulti<NKJPGender>(parts[3])), degree: parts[4] as NKJPDegree }
+    case 'fin':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), person: parts[2] as NKJPPerson, aspect: parts[3] as NKJPAspect }
+    case 'praet':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), ...spread('genders', splitMulti<NKJPGender>(parts[2])), aspect: parts[3] as NKJPAspect }
+    case 'impt':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), person: parts[2] as NKJPPerson, aspect: parts[3] as NKJPAspect }
+    case 'ger':
+    case 'pact':
+    case 'ppas':
+      return { ...base, ...spread('number', splitMulti<NKJPNumber>(parts[1])), ...spread('cases', splitMulti<NKJPCase>(parts[2])), ...spread('genders', splitMulti<NKJPGender>(parts[3])), aspect: parts[4] as NKJPAspect, negation: parts[5] as 'aff' | 'neg' }
+    default:
+      return { ...base, aspect: parts[1] as NKJPAspect }
+  }
+}
+
+export const CASE_LABELS: Record<NKJPCase, string> = {
+  nom: 'Nominative', gen: 'Genitive', dat: 'Dative',
+  acc: 'Accusative', inst: 'Instrumental', loc: 'Locative', voc: 'Vocative',
+}
+export const CASE_ORDER: NKJPCase[] = ['nom', 'gen', 'dat', 'acc', 'inst', 'loc', 'voc']
+export const NUMBER_LABELS: Record<NKJPNumber, string> = { sg: 'Singular', pl: 'Plural' }
+export const PERSON_LABELS: Record<NKJPPerson, string> = { pri: '1st', sec: '2nd', ter: '3rd' }
+export const PERSON_ORDER: NKJPPerson[] = ['pri', 'sec', 'ter']
+export const DEGREE_LABELS: Record<NKJPDegree, string> = { pos: 'Positive', com: 'Comparative', sup: 'Superlative' }
+export const GENDER_LABELS: Record<NKJPGender, string> = {
+  m1: 'Masc. Personal', m2: 'Masc. Animate', m3: 'Masc. Inanimate', f: 'Feminine', n: 'Neuter',
+}
+
+export interface MorphFormData {
+  id: string
+  lemmaId: string
+  orth: string
+  tag: string
+  parsedTag: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary

- **Replaces the flat form list** on the lemma detail page with structured paradigm tables grouped by Polish grammar conventions
- **Parses raw NKJP tags** directly (not the `parsedTag` JSON) — handles multi-value features like `nom.acc.voc` by expanding forms into all matching cells
- **POS-specific table components:**
  - `NounTable` — declension grid (7 cases × singular/plural)
  - `VerbTable` — conjugation sections: infinitive, present (person × number), past (gender × number), imperative, adverbial participles, verbal noun, active/passive participles
  - `AdjTable` — sub-tables per degree (positive/comparative/superlative), each with case rows × gender columns (sg masc/fem/neut, pl m-personal/other)
  - `FlatFormTable` — fallback for adverbs and unknown POS types

## New files

| File | Purpose |
|------|---------|
| `packages/web/src/utils/nkjp.ts` | NKJP tag parser + label/order constants |
| `packages/web/src/components/paradigm/NounTable.tsx` | Noun declension table |
| `packages/web/src/components/paradigm/VerbTable.tsx` | Verb conjugation sections |
| `packages/web/src/components/paradigm/AdjTable.tsx` | Adjective degree tables |
| `packages/web/src/components/paradigm/FlatFormTable.tsx` | Fallback flat table |

## Test plan

- [ ] Navigate to a noun lemma (e.g. "dom") — verify 7-row × 2-column declension table renders
- [ ] Navigate to a verb lemma (e.g. "iść") — verify all applicable sections render (infinitive, present, past, imperative, participles)
- [ ] Navigate to an adjective lemma — verify degree sub-tables render with correct gender columns
- [ ] Navigate to an adverb or unknown POS lemma — verify flat table fallback renders
- [ ] Verify empty cells show "—" in muted style
- [ ] Verify multi-value tags (e.g. `nom.acc.voc`) fill all matching cells
- [ ] Check responsive behavior — tables should scroll horizontally on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)