### PR TITLE
test(core): add comprehensive FSRS scheduler test suite

### DIFF
--- a/packages/core/src/scheduler.test.ts
+++ b/packages/core/src/scheduler.test.ts
@@ -11,7 +11,11 @@ const NOW = new Date("2026-01-15T12:00:00.000Z");
 
 function makeCard(overrides: Partial<Card> = {}): Card {
   const base = createCard("note-uuid-1", "morph_form", "subst:sg:nom:m3");
-  return { id: "card-uuid-1", ...base, ...overrides };
+  // Pin `due` to NOW so elapsed-day calculations in scheduleReview are
+  // deterministic regardless of when the test suite runs. createEmptyCard()
+  // (called inside createCard) sets due to real wall-clock time; overriding
+  // it here ensures fixtures are fully time-independent.
+  return { id: "card-uuid-1", ...base, due: NOW, ...overrides };
 }
 
 function makeMatureCard(): Card {
@@ -23,6 +27,8 @@ function makeMatureCard(): Card {
     lapses: 0,
     scheduledDays: 10,
     elapsedDays: 10,
+    // due = lastReview + scheduledDays = 2026-01-05 + 10d = 2026-01-15 = NOW
+    due: NOW,
     lastReview: new Date("2026-01-05T12:00:00.000Z"),
   });
 }
@@ -36,6 +42,7 @@ function makeRelearningCard(): Card {
     lapses: 2,
     scheduledDays: 0,
     elapsedDays: 0,
+    due: NOW,
     lastReview: new Date("2026-01-15T10:00:00.000Z"),
   });
 }


### PR DESCRIPTION
## Summary

Adds 34 `bun test` tests for the `@strus/core` FSRS scheduler — the first tests in the monorepo.

## Coverage

**`createCard`**
- Initial state (New, reps=0, lapses=0)
- kind and tag assignment
- `exactOptionalPropertyTypes` guard: `lastReview` and `tag` keys must be **absent** on new cards (not merely `undefined`) — catches silent regressions in the optional property handling

**`scheduleReview` — new card**
- All 4 ratings × state transition assertions
- Again: due within 1 hour (short learning interval)
- Easy: moves directly to Review with scheduledDays > 0
- Pure function invariant: input card not mutated

**`scheduleReview` — mature Review card**
- Again → Relearning with `lapses + 1` (regression guard for the `toFsrsCard`/`applyFsrsCard` integer enum roundtrip)
- Interval ordering: Hard < Good < Easy
- `lastReview` set to review time for all ratings

**`scheduleReview` — Relearning card**
- Again stays Relearning
- Good → Review

**`getNextReviewDates`**
- Returns Date objects for all 4 ratings
- Ordering invariant: Again ≤ Hard ≤ Good ≤ Easy
- Pure function invariant

## Notes

All tests use a fixed `NOW = new Date("2026-01-15T12:00:00.000Z")` for deterministic assertions. No mocking needed — `@strus/core` has zero external runtime dependencies (ts-fsrs is a pure TS library).