### PR TITLE
fix(api): always create morph note for manual lemmas

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -646,8 +646,11 @@ const lemmasCreate = os
       }).catch((err) => {
         console.warn(`[media] Image generation failed for "${input.lemma}":`, err);
       });
-    } else if (input.listId) {
-      // Manual source: create a morph note (with no forms) and add to list
+    } else {
+      // Manual source: ALWAYS create a morph note (even without a listId).
+      // Without this, listsAddLemma throws NOT_FOUND for any manual lemma
+      // that was created before being added to a list, because it queries
+      // for a morph note and finds none.
       const noteId = crypto.randomUUID();
       await db.insert(notes).values({
         id: noteId,
@@ -658,7 +661,9 @@ const lemmasCreate = os
         createdAt: now,
         updatedAt: now,
       });
-      await db.insert(vocabListNotes).values({ listId: input.listId, noteId });
+      if (input.listId) {
+        await db.insert(vocabListNotes).values({ listId: input.listId, noteId });
+      }
     }
 
     return mapLemma({

--- a/packages/db/migrations/0007_repair_manual_lemma_morph_notes.sql
+++ b/packages/db/migrations/0007_repair_manual_lemma_morph_notes.sql
@@ -1,0 +1,22 @@
+-- Backfill morph notes for existing manual lemmas that have none.
+-- Idempotent: NOT EXISTS guard prevents duplicates.
+INSERT INTO notes (id, kind, lemma_id, front, back, last_reviewed_at, created_at, updated_at)
+SELECT
+  lower(
+    hex(randomblob(4)) || '-' ||
+    hex(randomblob(2)) || '-4' ||
+    substr(hex(randomblob(2)), 2) || '-' ||
+    substr('89ab', abs(random()) % 4 + 1, 1) ||
+    substr(hex(randomblob(2)), 2) || '-' ||
+    hex(randomblob(6))
+  ),
+  'morph',
+  l.id,
+  NULL, NULL, NULL,
+  unixepoch(),
+  unixepoch()
+FROM lemmas l
+WHERE l.source = 'manual'
+  AND NOT EXISTS (
+    SELECT 1 FROM notes n WHERE n.lemma_id = l.id AND n.kind = 'morph'
+  );

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772714116164,
       "tag": "0006_slim_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1772831760000,
+      "tag": "0007_repair_manual_lemma_morph_notes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Problem

`POST /lists/{listId}/lemmas` (`listsAddLemma`) was broken for any manual lemma created without an upfront `listId`.

The handler queries:
```sql
SELECT id FROM notes WHERE lemma_id = ? AND kind = 'morph' LIMIT 1
```
…and throws `NOT_FOUND` when it gets nothing back.

This happened because `lemmasCreate` only created the morph note when `source='manual' && listId` — so a lemma created with `{ source: 'manual' }` (no list) had no morph note at all, and could never be linked to a list afterwards.

## Fix

Remove the `else if (input.listId)` guard so the morph note is **always** created for manual lemmas. The `vocabListNotes` row is still only inserted when `listId` is present.

```ts
// Before (bug): morph note only created when listId is set
} else if (input.listId) {
  // ... note insert ...
  await db.insert(vocabListNotes)...

// After: always create note; conditionally link to list
} else {
  // ... note insert ...
  if (input.listId) {
    await db.insert(vocabListNotes)...
  }
}
```

## Migration 0007

Backfills morph notes for any existing manual lemmas that were created without one. Uses a `NOT EXISTS` guard — safe to run multiple times.

## Why Option A over Option B

The morph note is the learnable identity of the lemma, not an artifact of list membership. Creating it on-demand in `listsAddLemma` (Option B) would make an association endpoint responsible for object creation, diverging from the `source='morfeusz'` and `importCommit` paths.