### PR TITLE
feat(db): add missing FK indexes and fix settings.updatedAt type

### DIFF
--- a/packages/api/src/settings.ts
+++ b/packages/api/src/settings.ts
@@ -25,7 +25,7 @@ export function getSetting(key: string): string {
 }
 
 export function setSetting(key: string, value: string): void {
-  const updatedAt = new Date().toISOString();
+  const updatedAt = new Date();
   db.insert(settings)
     .values({ key, value, updatedAt })
     .onConflictDoUpdate({ target: settings.key, set: { value, updatedAt } })

--- a/packages/db/migrations/0008_overjoyed_ronan.sql
+++ b/packages/db/migrations/0008_overjoyed_ronan.sql
@@ -1,0 +1,13 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_settings`("key", "value", "updated_at") SELECT "key", "value", unixepoch("updated_at") FROM `settings`;--> statement-breakpoint
+DROP TABLE `settings`;--> statement-breakpoint
+ALTER TABLE `__new_settings` RENAME TO `settings`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `morph_forms_lemma_id_idx` ON `morph_forms` (`lemma_id`);--> statement-breakpoint
+CREATE INDEX `notes_lemma_id_idx` ON `notes` (`lemma_id`);

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772831760000,
       "tag": "0007_repair_manual_lemma_morph_notes",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1772837030557,
+      "tag": "0008_overjoyed_ronan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -15,7 +15,8 @@ import { sql } from "drizzle-orm";
 export const settings = sqliteTable("settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
-  updatedAt: text("updated_at").notNull(),
+  // integer timestamp consistent with all other tables (was text/ISO-string)
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
 // ---------------------------------------------------------------------------
@@ -67,7 +68,11 @@ export const notes = sqliteTable("notes", {
   lastReviewedAt: integer("last_reviewed_at"),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
-});
+}, (t) => [
+  // lemmaId is queried in listsAddLemma, notesCreate, notesList, and sessionDue.
+  // SQLite does NOT auto-index FK columns — explicit index required.
+  index("notes_lemma_id_idx").on(t.lemmaId),
+]);
 
 // ---------------------------------------------------------------------------
 // vocabListNotes  (join table)
@@ -102,7 +107,11 @@ export const morphForms = sqliteTable("morph_forms", {
   /** Relative path to generated TTS audio file, e.g. "audio/dom-subst-sg-nom-m3.mp3" */
   audioPath: text("audio_path"),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
-});
+}, (t) => [
+  // lemmaId is batch-fetched in sessionDue (WHERE lemmaId IN (...)) over
+  // potentially large sets. SQLite does NOT auto-index FK columns.
+  index("morph_forms_lemma_id_idx").on(t.lemmaId),
+]);
 
 // ---------------------------------------------------------------------------
 // cards


### PR DESCRIPTION
## Changes

### 1. Indexes on `morphForms.lemmaId` and `notes.lemmaId`

SQLite never auto-indexes FK columns — the constraint only enforces integrity, it provides zero query-planning benefit.

Both columns are frequent `WHERE` predicates:
- **`morphForms.lemmaId`**: batch-fetched in `sessionDue` with `WHERE lemmaId IN (...)` over all session lemmas. At 1000 lemmas × ~30 forms each = 30k row full scan on every session load.
- **`notes.lemmaId`**: queried in `listsAddLemma`, `notesCreate`, `notesList`, and `sessionDue`.

Added via `index()` in the Drizzle table callbacks. Migration 0008 emits the two `CREATE INDEX` statements — additive, zero risk.

### 2. `settings.updatedAt`: `text` → `integer({ mode: 'timestamp' })`

Every other timestamp column uses `integer({ mode: 'timestamp' })` (Unix epoch seconds, auto-converted to/from `Date`). `settings.updatedAt` was the only exception, storing ISO-8601 strings.

**Migration note**: the recreate-and-copy migration uses `unixepoch("updated_at")` to convert existing rows. Without this, SQLite's implicit text→integer coercion would silently truncate `"2026-03-06T..."` to `2026` (just the year).

**`settings.ts`** updated to pass `new Date()` instead of `toISOString()` — Drizzle's `mode='timestamp'` handles serialization.