### PR TITLE
refactor(web): replace any annotations with InferRouterOutputs types

### DIFF
--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared API output types derived from the server-side router via
+ * InferRouterOutputs. Import these instead of writing `any` annotations on
+ * createResource calls or For iterators.
+ *
+ * Preferred over Awaited<ReturnType<RouterClient<Router>[...]>> because it
+ * operates directly on the server-side Zod schema inference and is the
+ * canonical oRPC idiom.
+ */
+import type { InferRouterOutputs } from '@orpc/server'
+import type { Router } from '@strus/api/router'
+
+type RouterOutputs = InferRouterOutputs<Router>
+
+// ---------------------------------------------------------------------------
+// Lemmas
+// ---------------------------------------------------------------------------
+
+export type LemmaItem = RouterOutputs['lemmas']['list'][number]
+export type LemmaDetail = RouterOutputs['lemmas']['get']
+export type MorphFormItem = RouterOutputs['lemmas']['forms'][number]
+
+// ---------------------------------------------------------------------------
+// Notes
+// ---------------------------------------------------------------------------
+
+export type NoteListItem = RouterOutputs['notes']['list'][number]
+export type NoteDetail = RouterOutputs['notes']['get']
+export type CardItem = NoteDetail['cards'][number]
+
+// ---------------------------------------------------------------------------
+// Reviews
+// ---------------------------------------------------------------------------
+
+export type ReviewItem = RouterOutputs['cards']['reviews'][number]
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+export type DueCard = RouterOutputs['session']['due'][number]
+
+// ---------------------------------------------------------------------------
+// Lists
+// ---------------------------------------------------------------------------
+
+export type VocabListItem = RouterOutputs['lists']['list'][number]

--- a/packages/web/src/routes/lemmas/index.tsx
+++ b/packages/web/src/routes/lemmas/index.tsx
@@ -2,6 +2,7 @@ import { createResource, createSignal, createMemo, For, Show, Suspense, ErrorBou
 import { A } from '@solidjs/router'
 import { css } from '../../../styled-system/css'
 import { api } from '../../api/client'
+import type { LemmaItem } from '../../api/types'
 import { Button } from '../../components/Button'
 import { Badge } from '../../components/Badge'
 import { Spinner } from '../../components/Spinner'
@@ -13,7 +14,7 @@ import * as Table from '../../components/ui/table'
 const POS_OPTIONS = ['', 'subst', 'verb', 'adj', 'adv'] as const
 
 export default function LemmasIndex() {
-  const [lemmas, { refetch }] = createResource(() => api.lemmas.list({}))
+  const [lemmas, { refetch }] = createResource<LemmaItem[]>(() => api.lemmas.list({}))
   const [search, setSearch] = createSignal('')
   const [posFilter, setPosFilter] = createSignal('')
   const [sourceFilter, setSourceFilter] = createSignal('')
@@ -30,7 +31,7 @@ export default function LemmasIndex() {
     const data = lemmas()
     if (!data) return []
     const s = search().toLowerCase()
-    return data.filter((l: any) => {
+    return data.filter((l) => {
       if (s && !l.lemma.toLowerCase().includes(s)) return false
       if (posFilter() && l.pos !== posFilter()) return false
       if (sourceFilter() && l.source !== sourceFilter()) return false
@@ -163,7 +164,7 @@ export default function LemmasIndex() {
                   </Table.Head>
                   <Table.Body>
                     <For each={filtered()}>
-                      {(lemma: any) => (
+                      {(lemma) => (
                         <Table.Row>
                           <Table.Cell>
                             <A href={`/lemmas/${lemma.id}`} class={css({ color: 'blue.9', textDecoration: 'none', fontWeight: 'medium', _hover: { textDecoration: 'underline' } })}>

--- a/packages/web/src/routes/lists/[id].tsx
+++ b/packages/web/src/routes/lists/[id].tsx
@@ -1,7 +1,8 @@
-import { createResource, createSignal, For, Show, Suspense, ErrorBoundary } from 'solid-js'
+import { createResource, createSignal, createMemo, For, Show, Suspense, ErrorBoundary } from 'solid-js'
 import { useParams, useNavigate, A } from '@solidjs/router'
 import { css } from '../../../styled-system/css'
 import { api } from '../../api/client'
+import type { LemmaItem } from '../../api/types'
 import { Button } from '../../components/Button'
 import { Badge } from '../../components/Badge'
 import { Spinner } from '../../components/Spinner'
@@ -18,7 +19,7 @@ export default function ListDetail() {
   const navigate = useNavigate()
 
   const [list, { refetch: refetchList }] = createResource(() => api.lists.get({ id: params.id }))
-  const [lemmas, { refetch: refetchLemmas }] = createResource(() => api.lemmas.list({ listId: params.id }))
+  const [lemmas, { refetch: refetchLemmas }] = createResource<LemmaItem[]>(() => api.lemmas.list({ listId: params.id }))
 
   const [showDeleteList, setShowDeleteList] = createSignal(false)
   const [deletingList, setDeletingList] = createSignal(false)
@@ -30,19 +31,23 @@ export default function ListDetail() {
   const [source, setSource] = createSignal<string>('morfeusz')
   const [adding, setAdding] = createSignal(false)
 
-  const [allLemmas] = createResource(
+  const [allLemmas] = createResource<LemmaItem[]>(
     () => showAddForm() || undefined,
     () => api.lemmas.list({}),
   )
   const [existingSearch, setExistingSearch] = createSignal('')
   const [addingExistingId, setAddingExistingId] = createSignal<string | null>(null)
 
-  const filteredExistingLemmas = () => {
+  // createMemo — not a plain function — so SolidJS caches the result and only
+  // recomputes when allLemmas(), lemmas(), or existingSearch() changes.
+  // This function is called twice in JSX; without memo it would compute twice
+  // per reactive update (including the Set construction over all lemmas).
+  const filteredExistingLemmas = createMemo(() => {
     const all = allLemmas() ?? []
-    const currentIds = new Set((lemmas() ?? []).map((l: any) => l.id))
+    const currentIds = new Set((lemmas() ?? []).map((l) => l.id))
     const search = existingSearch().toLowerCase().trim()
-    return all.filter((l: any) => !currentIds.has(l.id) && (!search || l.lemma.toLowerCase().includes(search)))
-  }
+    return all.filter((l) => !currentIds.has(l.id) && (!search || l.lemma.toLowerCase().includes(search)))
+  })
 
   const handleAddExisting = async (lemmaId: string) => {
     setAddingExistingId(lemmaId)
@@ -197,7 +202,7 @@ export default function ListDetail() {
                           >
                             <div class={css({ maxHeight: '200px', overflowY: 'auto', border: '1px solid', borderColor: 'border', borderRadius: 'l2' })}>
                               <For each={filteredExistingLemmas()}>
-                                {(lemma: any) => (
+                                {(lemma) => (
                                   <div class={css({ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '3', py: '2', borderBottom: '1px solid', borderColor: 'border', _last: { borderBottom: 'none' } })}>
                                     <div class={css({ display: 'flex', alignItems: 'center', gap: '2' })}>
                                       <span class={css({ fontSize: 'sm', fontWeight: 'medium', color: 'fg.default' })}>{lemma.lemma}</span>
@@ -235,7 +240,7 @@ export default function ListDetail() {
                           </Table.Head>
                           <Table.Body>
                             <For each={lemmaData()}>
-                              {(lemma: any) => (
+                              {(lemma) => (
                                 <Table.Row>
                                   <Table.Cell>
                                     <A href={`/lemmas/${lemma.id}`} class={css({ color: 'blue.9', textDecoration: 'none', fontWeight: 'medium', _hover: { textDecoration: 'underline' } })}>

--- a/packages/web/src/routes/notes/[id].tsx
+++ b/packages/web/src/routes/notes/[id].tsx
@@ -2,6 +2,7 @@ import { createResource, createSignal, createMemo, For, Show, Suspense, ErrorBou
 import { useParams, useNavigate, A } from '@solidjs/router'
 import { css } from '../../../styled-system/css'
 import { api } from '../../api/client'
+import type { NoteDetail, CardItem, ReviewItem, MorphFormItem } from '../../api/types'
 import { Button } from '../../components/Button'
 import { Spinner } from '../../components/Spinner'
 import { ErrorState } from '../../components/ErrorState'
@@ -109,10 +110,10 @@ export default function NoteDetail() {
   const params = useParams<{ id: string }>()
   const navigate = useNavigate()
 
-  const [note, { refetch }] = createResource(() => api.notes.get({ id: params.id }))
+  const [note, { refetch }] = createResource<NoteDetail>(() => api.notes.get({ id: params.id }))
   // Fetch morph forms so we can show the answer alongside each morph_form card
   // Source returns undefined when no lemmaId — SolidJS skips the fetcher in that case
-  const [lemmaForms] = createResource(
+  const [lemmaForms] = createResource<MorphFormItem[]>(
     () => note()?.lemmaId ?? undefined,
     (lemmaId: string) => api.lemmas.forms({ id: lemmaId })
   )
@@ -127,7 +128,7 @@ export default function NoteDetail() {
 
   // Review history expansion state
   const [expandedCards, setExpandedCards] = createSignal<Set<string>>(new Set())
-  const [reviewCache, setReviewCache] = createSignal<Record<string, any[]>>({})
+  const [reviewCache, setReviewCache] = createSignal<Record<string, ReviewItem[]>>({})
   const [loadingReviews, setLoadingReviews] = createSignal<Set<string>>(new Set())
 
   const toggleCardReviews = async (cardId: string) => {
@@ -149,7 +150,7 @@ export default function NoteDetail() {
       setLoadingReviews(prev => { const s = new Set(prev); s.add(cardId); return s })
       try {
         const revs = await api.cards.reviews({ id: cardId })
-        setReviewCache(prev => ({ ...prev, [cardId]: revs as any[] }))
+        setReviewCache(prev => ({ ...prev, [cardId]: revs }))
       } catch (err) {
         console.error('Failed to fetch reviews:', err)
         setReviewCache(prev => ({ ...prev, [cardId]: [] }))
@@ -349,7 +350,7 @@ export default function NoteDetail() {
                 >
                   <div class={css({ display: 'flex', flexDirection: 'column', gap: '3' })}>
                     <For each={data().cards}>
-                      {(card: any) => (
+                      {(card) => (
                         <div class={css({
                           p: '4',
                           border: '1px solid',
@@ -429,7 +430,7 @@ export default function NoteDetail() {
                                 >
                                   <div class={css({ display: 'flex', flexDirection: 'column', gap: '1' })}>
                                     <For each={reviewCache()[card.id]}>
-                                      {(rev: any) => {
+                                      {(rev) => {
                                         const meta = ratingMeta[rev.rating as number] ?? { label: '?', color: 'fg.muted', bg: 'gray.3' }
                                         return (
                                           <div class={css({ display: 'flex', gap: '3', alignItems: 'center', fontSize: 'xs', py: '1' })}>
@@ -470,7 +471,7 @@ export default function NoteDetail() {
                   {(() => {
                     const [showAll, setShowAll] = createSignal(false)
                     const PREVIEW_LIMIT = 5
-                    const allCards = () => data().cards as any[]
+                    const allCards = () => data().cards as CardItem[]
                     const visibleCards = () => showAll() || allCards().length <= PREVIEW_LIMIT
                       ? allCards()
                       : allCards().slice(0, PREVIEW_LIMIT)
@@ -479,7 +480,7 @@ export default function NoteDetail() {
                       <>
                         <div class={css({ display: 'flex', flexDirection: 'column', gap: '3', mb: '6' })}>
                           <For each={visibleCards()}>
-                            {(card: any) => (
+                            {(card) => (
                               <QuizCardPreview
                                 kind={card.kind}
                                 tag={card.tag ?? null}

--- a/packages/web/src/routes/notes/index.tsx
+++ b/packages/web/src/routes/notes/index.tsx
@@ -1,4 +1,5 @@
 import { createResource, createSignal, createMemo, For, Show, Suspense, ErrorBoundary } from 'solid-js'
+import type { NoteListItem } from '../../api/types'
 import { A } from '@solidjs/router'
 import { css } from '../../../styled-system/css'
 import { api } from '../../api/client'
@@ -37,7 +38,7 @@ function KindBadge(props: { kind: string }) {
 }
 
 export default function NotesIndex() {
-  const [notes, { refetch }] = createResource(() => api.notes.list({}))
+  const [notes, { refetch }] = createResource<NoteListItem[]>(() => api.notes.list({}))
   const [kindFilter, setKindFilter] = createSignal('')
   const [deleteId, setDeleteId] = createSignal<string | null>(null)
   const [deleting, setDeleting] = createSignal(false)
@@ -48,7 +49,7 @@ export default function NotesIndex() {
     if (!data) return []
     const k = kindFilter()
     if (!k) return data
-    return data.filter((n: any) => n.kind === k)
+    return data.filter((n) => n.kind === k)
   })
 
   const handleDelete = async () => {
@@ -69,7 +70,7 @@ export default function NotesIndex() {
     border: '1px solid', borderColor: 'border', bg: 'bg', color: 'fg.default',
   })
 
-  function notePreview(note: any): string {
+  function notePreview(note: NoteListItem): string {
     const truncate = (s: string) => s.length > 60 ? s.slice(0, 60) + '…' : s
     if (note.kind === 'morph') return note.lemmaText ? truncate(note.lemmaText) : '—'
     if (note.kind === 'gloss') {
@@ -122,7 +123,7 @@ export default function NotesIndex() {
                   </Table.Head>
                   <Table.Body>
                     <For each={filtered()}>
-                      {(note: any) => (
+                      {(note) => (
                         <Table.Row>
                           <Table.Cell>
                             <KindBadge kind={note.kind} />

--- a/packages/web/src/routes/quiz/index.tsx
+++ b/packages/web/src/routes/quiz/index.tsx
@@ -387,14 +387,29 @@ export default function Quiz() {
     const card = currentCard()
     if (!card) return
 
-    if (card.kind === 'basic_forward' || card.kind === 'gloss_forward' || card.kind === 'gloss_reverse' || card.forms.length === 0) {
-      setPhase('revealed-manual')
-      return
+    switch (card.kind) {
+      case 'basic_forward':
+      case 'gloss_forward':
+      case 'gloss_reverse':
+        setPhase('revealed-manual')
+        return
+      case 'morph_form': {
+        if (card.forms.length === 0) {
+          // No expected forms available — fall back to manual reveal
+          setPhase('revealed-manual')
+          return
+        }
+        const userAnswer = answer().trim()
+        const ok = card.forms.some(f => f.toLowerCase() === userAnswer.toLowerCase())
+        setPhase(ok ? 'revealed-correct' : 'revealed-wrong')
+        return
+      }
+      default:
+        // Exhaustiveness guard: TypeScript will error here if a new card kind
+        // is added to the union without updating this switch.
+        card.kind satisfies never
+        setPhase('revealed-manual')
     }
-
-    const userAnswer = answer().trim()
-    const ok = card.forms.some(f => f.toLowerCase() === userAnswer.toLowerCase())
-    setPhase(ok ? 'revealed-correct' : 'revealed-wrong')
   }
 
   const submitReview = async (rating: 1 | 2 | 3 | 4) => {


### PR DESCRIPTION
## Summary

Eliminates all `any` type annotations across 4 route files and adds a `checkAnswer` exhaustiveness guard in the quiz.

## New file: `packages/web/src/api/types.ts`

Exports named types via `InferRouterOutputs<Router>` — the canonical oRPC utility (preferred over `Awaited<ReturnType<RouterClient<Router>[...]>>` because it operates directly on server-side Zod schema inference).

```ts
export type LemmaItem = RouterOutputs['lemmas']['list'][number]
export type NoteListItem = RouterOutputs['notes']['list'][number]
export type CardItem = NoteDetail['cards'][number]
export type ReviewItem = RouterOutputs['cards']['reviews'][number]
// ... etc
```

## Changes by file

**`lemmas/index.tsx`** — `createResource<LemmaItem[]>`, filter and `For` iterator infer from the generic

**`lists/[id].tsx`**
- Both `createResource` calls typed as `LemmaItem[]`
- `filteredExistingLemmas` converted from plain function → `createMemo`: it reads 3 reactive signals and is called twice in JSX. Without memo, SolidJS computes it twice per reactive update (including the `new Set` construction). `createMemo` caches and recomputes only on dependency change.
- `createMemo` added to the `solid-js` import

**`notes/index.tsx`** — `createResource<NoteListItem[]>`, `notePreview(note: NoteListItem)`

**`notes/[id].tsx`**
- `createResource<NoteDetail>` and `createResource<MorphFormItem[]>`
- `reviewCache`: `Record<string, ReviewItem[]>` (was `Record<string, any[]>`)
- `revs as any[]` cast removed — `api.cards.reviews` returns `ReviewItem[]`
- `data().cards as any[]` → `data().cards as CardItem[]`

**`quiz/index.tsx`** — `checkAnswer` refactored from implicit-negation if-chain to `switch` with `satisfies never` exhaustiveness guard in `default`. TypeScript will now emit a compile error if a new card kind is added to the `DueCard` union without updating this switch.