### PR TITLE
fix: fire-and-forget image gen in importCommit; fix CLI lemmaText type

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1609,6 +1609,27 @@ const importCommit = os
         if (input.listId !== undefined) {
           await db.insert(vocabListNotes).values({ listId: input.listId, noteId });
         }
+
+        // Fire-and-forget image generation — mirrors lemmasCreate behaviour.
+        // Swallows failures (rate-limit, network) so the import response is
+        // never blocked by media generation.
+        const citationForm = db
+          .select({ tag: morphForms.tag })
+          .from(morphForms)
+          .where(and(eq(morphForms.lemmaId, id), eq(morphForms.orth, c.lemma)))
+          .limit(1)
+          .get();
+        const citationTag = citationForm?.tag ?? "";
+        generateImage(c.lemma, citationTag).then((result) => {
+          if (result.relativePath || result.imagePrompt) {
+            db.update(lemmas).set({
+              ...(result.relativePath ? { imagePath: result.relativePath } : {}),
+              ...(result.imagePrompt ? { imagePrompt: result.imagePrompt } : {}),
+            }).where(eq(lemmas.id, id)).run();
+          }
+        }).catch((err) => {
+          console.warn(`[media] Import image generation failed for "${c.lemma}":`, err);
+        });
       } else {
         // Manual source: create a morph note (with no forms)
         const noteId = crypto.randomUUID();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -464,7 +464,7 @@ program
       lemmaId: string;
       tag: string;
       state: number;
-      lemmaText: string;
+      lemmaText: string | null;
       front: string | null;
       back: string | null;
       forms: string[];
@@ -495,7 +495,7 @@ program
         const label = card.kind === "basic_forward" ? "Basic" : card.kind === "gloss_forward" ? "Gloss (→ meaning)" : card.kind === "gloss_reverse" ? "Gloss (→ word)" : "Card";
         console.log(`${label}    : ${card.front}`);
       } else {
-        console.log(`Lemma     : ${card.lemmaText}`);
+        console.log(`Lemma     : ${card.lemmaText ?? "(unknown)"}`);
         console.log(`Tag       : ${card.tag}`);
       }
       console.log("─".repeat(40));


### PR DESCRIPTION
## Changes

### `importCommit` — image generation for bulk imports

`POST /import/text` now fires image generation for each `morfeusz`-source lemma after its morph note and cards are created. This mirrors the identical fire-and-forget pattern already in `lemmasCreate`.

Previously, bulk-imported lemmas had `imagePath = NULL` and `imagePrompt = NULL` indefinitely unless someone called `POST /lemmas/{id}/generate-image` manually.

Failures (Gemini 429 rate limits, network errors) are caught and logged as `console.warn` so the import response is never blocked by media generation — same behaviour as `lemmasCreate`.

### CLI `DueCard.lemmaText` type fix

The local `DueCard` interface had `lemmaText: string` (non-nullable), but the API schema returns `string | null` for non-lemma-backed cards (e.g. `basic_forward`). The display now falls back to `"(unknown)"` when `null`.