### PR TITLE
docs(api): update CLAUDE.md; update strus skill reference

### DIFF
--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -8,7 +8,9 @@ Elysia HTTP server with oRPC for type-safe routing and automatic OpenAPI spec ge
 packages/api/
 ├── src/
 │   ├── index.ts      — server entry: migrations, spec generation, Elysia app, listen
-│   └── router.ts     — all oRPC procedures and the router export
+│   ├── router.ts     — all oRPC procedures and the router export
+│   ├── media.ts      — Gemini image generation + ElevenLabs audio generation
+│   └── settings.ts   — key-value settings table helpers (getSetting/setSetting)
 └── scripts/
     └── generate-spec.ts  — standalone script: writes openapi.json to disk
 ```
@@ -40,12 +42,7 @@ const myProcedure = os
   });
 ```
 
-Then add to the router:
-```ts
-export const router = {
-  things: { get: myProcedure, … },
-};
-```
+Then add to the router object at the bottom of `router.ts`.
 
 ## Mounting the oRPC Handler
 
@@ -81,45 +78,7 @@ const spec = await generator.generate(router, { info: { … }, servers: […], t
 The `ZodToJsonSchemaConverter` import comes from `@orpc/zod` main entry — this is the Zod v3
 converter. **Do not** use `@orpc/zod/zod4`.
 
-## Zod Schemas
-
-## API Endpoints
-
-### Lists (`/lists`)
-- `GET /lists` — list all vocabulary lists
-- `POST /lists` — create a vocabulary list
-- `GET /lists/{id}` — get a vocabulary list
-- `DELETE /lists/{id}` — delete a vocabulary list
-- `POST /lists/{listId}/lemmas` — add a lemma to a list
-
-### Notes (`/notes`)
-- `POST /notes` — create a basic note (and its basic_forward card)
-- `GET /notes` — list notes (optionally filter by kind and/or listId)
-- `GET /notes/{id}` — get a note with its cards
-- `DELETE /notes/{id}` — delete a note (cascades to cards)
-- `PATCH /notes/{id}` — update front/back of a basic note
-
-### Lemmas (`/lemmas`)
-- `GET /lemmas` — list lemmas
-- `POST /lemmas` — create a lemma (auto-generates morph forms if source=morfeusz)
-- `GET /lemmas/{id}` — get a lemma
-- `DELETE /lemmas/{id}` — delete a lemma (cascades)
-- `GET /lemmas/{id}/forms` — get morphological forms
-
-### Session (`/session`)
-- `GET /session/due` — get cards due for review (supports morph + basic cards)
-- `POST /session/review` — record a review rating
-
-### Stats (`/stats`)
-- `GET /stats` — overview statistics
-
-### Import (`/import`)
-- `POST /import/text/preview` — preview text import candidates
-- `POST /import/text` — import lemmas from text
-
-## Zod Schemas
-
-Common building blocks defined at the top of `router.ts`:
+## Zod Schema Conventions
 
 ```ts
 const zId  = z.string().uuid().describe("UUID v4 identifier");
@@ -127,9 +86,9 @@ const zIso = z.string().datetime().describe("ISO 8601 date-time string");
 const zSource = z.enum(["morfeusz", "manual"]);
 ```
 
-`integer({ mode: "timestamp" })` columns → Drizzle returns `Date` → use `z.date()` or
-`.toISOString()` + `zIso` in output schemas. Plain `integer()` Unix-second columns
-(e.g. `due`, `lastReview`) → `z.number().int()` or map to ISO strings via mapper functions.
+Column type → Zod:
+- `integer({ mode: "timestamp" })` → Drizzle returns `Date` → use `z.date()` or map to `zIso`
+- Plain `integer()` Unix-second columns (`due`, `lastReview`) → `z.number().int()` or map to ISO strings in handler
 
 ## Error Handling
 
@@ -141,6 +100,85 @@ throw new ORPCError("BAD_REQUEST", { message: "…" });
 ```
 
 Unhandled JS errors become `INTERNAL_SERVER_ERROR` (500).
+
+## Morphological Analysis
+
+The `@strus/morph` package wraps `@rzyns/morfeusz-ts` — a native Node/Bun binding to
+Morfeusz2. It uses **lazy singletons** (loaded once, reused across requests) and expects
+the SGJP dictionary files at `/usr/share/morfeusz2/dictionaries`. No subprocess is spawned.
+
+```ts
+import { analyseText, generate } from "@strus/morph";
+// analyseText(text: string) → Promise<MorphForm[]>
+// generate(lemma: string, tag: string) → Promise<MorphForm[]>
+```
+
+If the dictionary files are missing, `analyseText` and `generate` throw — callers get a 500.
+There is no silent degradation: missing morfeusz is a hard error.
+
+## API Endpoints
+
+### About
+- `GET /about` — server metadata (version, db path)
+
+### Lists (`/lists`)
+- `GET /lists` — list all vocabulary lists
+- `POST /lists` — create a vocabulary list
+- `GET /lists/{id}` — get a vocabulary list with note count
+- `DELETE /lists/{id}` — delete a vocabulary list
+- `POST /lists/{listId}/lemmas` — add a lemma to a list via its morph note (lemma must already have a morph note)
+
+### Lemmas (`/lemmas`)
+- `GET /lemmas` — list lemmas (optional `?listId=` filter)
+- `POST /lemmas` — create a lemma; if `source=morfeusz`, auto-generates morph forms and fires image generation
+- `GET /lemmas/{id}` — get a lemma
+- `DELETE /lemmas/{id}` — delete a lemma (cascades to notes, cards, reviews)
+- `GET /lemmas/{id}/forms` — get all morphological forms for a lemma
+- `POST /lemmas/{id}/generate-image` — (re)generate the Gemini image for a lemma; blocks until done
+
+### Notes (`/notes`)
+- `POST /notes` — create a note (`kind`: `morph` | `gloss` | `basic`)
+- `GET /notes` — list notes (optional `?kind=`, `?listId=`, `?lemmaId=` filters)
+- `GET /notes/{id}` — get a note with its cards and lemma
+- `DELETE /notes/{id}` — delete a note (cascades to cards, reviews)
+- `PATCH /notes/{id}` — update `front`/`back` (basic notes) or `back` (gloss notes); morph notes are read-only
+
+### Cards (`/cards`)
+- `GET /cards/{id}` — get a card
+- `GET /cards/{id}/reviews` — review history, newest first
+
+### Forms (`/forms`)
+- `POST /forms/{id}/generate-audio` — generate ElevenLabs audio for a morph form; blocks until done
+
+### Session (`/session`)
+- `GET /session/due` — get a composed session of due cards (supports all card kinds)
+- `POST /session/review` — record a card review rating (1=Again · 2=Hard · 3=Good · 4=Easy)
+
+### Stats (`/stats`)
+- `GET /stats` — overview: `{ lemmaCount, listCount, dueCount }`
+
+### Import (`/import`)
+- `POST /import/text/preview` — dry-run: tokenise Polish text, return candidates without writing
+- `POST /import/text` — commit import; fires fire-and-forget image generation per new morfeusz lemma
+
+### Settings (`/settings`)
+- `GET /settings` — get `imagePromptTemplate` (current Mustache template and factory default)
+- `POST /settings` — update `imagePromptTemplate`
+
+## Data Model Summary
+
+```
+lemmas ──< morph_forms        (one lemma → many NKJP-tagged surface forms)
+lemmas ──< notes              (one lemma → one morph note; also gloss notes)
+notes  ──< cards              (one note → one or more FSRS cards)
+cards  ──< reviews            (one card → many review records)
+vocab_lists ──< vocab_list_notes ──< notes   (lists contain notes, not lemmas directly)
+```
+
+Note kinds and their cards:
+- `morph` → `morph_form` cards (one per `morph_forms` row, keyed by tag)
+- `gloss` → `gloss_forward` + `gloss_reverse` cards
+- `basic` → `basic_forward` card
 
 ## Running the Server
 


### PR DESCRIPTION
## Summary

Documentation catch-up after all Phase 1–5 PRs.

### `packages/api/CLAUDE.md`

**Added missing endpoints:**
- `GET /about`
- `POST /lemmas/{id}/generate-image`
- `POST /forms/{id}/generate-audio`
- `GET /cards/{id}`
- `GET /cards/{id}/reviews`
- `GET /settings` + `POST /settings`

**Corrected `POST /lists/{listId}/lemmas`:** attaches via the lemma's morph note (uses `vocab_list_notes`), not a direct lemma FK — updated description reflects this.

**New: Morphological Analysis section**
- `@rzyns/morfeusz-ts` native binding to Morfeusz2 (no subprocess)
- Lazy singleton pattern (loaded once, reused across requests)
- Hard error on missing dict files — no silent degradation

**New: Data Model Summary**
- Full entity hierarchy: lemmas → morph_forms, lemmas → notes → cards → reviews
- vocab_lists ←→ vocab_list_notes ←→ notes (lists contain notes, not lemmas directly)
- Note kinds → card kinds mapping

**Updated: Key Files** — added `media.ts` and `settings.ts`

**Updated: Zod conventions** — timestamp column type mapping

### OpenClaw Strus Skill (applied separately to extension)

- `references/api.md`: added missing sections for Cards, Lemma Media, Form Audio, Settings, About, and Morph Pipeline
- `SKILL.md`: added Morph Pipeline section clarifying `@rzyns/morfeusz-ts` (no subprocess)