### PR TITLE
fix(core): persist FSRS learning_steps to cards table

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1311,6 +1311,7 @@ const sessionDue = os
         scheduledDays: r.card.scheduledDays,
         reps: r.card.reps,
         lapses: r.card.lapses,
+        learningSteps: r.card.learningSteps,
         ...(r.card.tag != null ? { tag: r.card.tag } : {}),
         ...(r.card.lastReview != null ? { lastReview: new Date(r.card.lastReview * 1000) } : {}),
       };
@@ -1401,6 +1402,7 @@ const sessionReview = os
       scheduledDays: row.scheduledDays,
       reps: row.reps,
       lapses: row.lapses,
+      learningSteps: row.learningSteps,
       ...(row.tag != null ? { tag: row.tag } : {}),
       ...(row.lastReview != null ? { lastReview: new Date(row.lastReview * 1000) } : {}),
     };
@@ -1418,6 +1420,7 @@ const sessionReview = os
         scheduledDays: updated.scheduledDays,
         reps: updated.reps,
         lapses: updated.lapses,
+        learningSteps: updated.learningSteps,
         lastReview: updated.lastReview
           ? Math.floor(updated.lastReview.getTime() / 1000)
           : null,
@@ -1672,6 +1675,7 @@ function insertCardValues(cardData: Omit<import("@strus/core").Card, "id">) {
     scheduledDays: cardData.scheduledDays,
     reps: cardData.reps,
     lapses: cardData.lapses,
+    learningSteps: cardData.learningSteps,
     lastReview: cardData.lastReview
       ? Math.floor(cardData.lastReview.getTime() / 1000)
       : null,

--- a/packages/core/src/scheduler.test.ts
+++ b/packages/core/src/scheduler.test.ts
@@ -52,11 +52,12 @@ function makeRelearningCard(): Card {
 // ---------------------------------------------------------------------------
 
 describe("createCard", () => {
-  test("creates a New state card with zero reps and lapses", () => {
+  test("creates a New state card with zero reps, lapses, and learningSteps", () => {
     const card = makeCard();
     expect(card.state).toBe(CardState.New);
     expect(card.reps).toBe(0);
     expect(card.lapses).toBe(0);
+    expect(card.learningSteps).toBe(0);
   });
 
   test("sets noteId and kind correctly", () => {

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -20,7 +20,6 @@ type ScoredFsrsRating = Exclude<FsrsRating, typeof FsrsRating.Manual>;
 /** Map our Card onto a ts-fsrs Card */
 function toFsrsCard(card: Card): FsrsCard {
   // CardState and ts-fsrs State share the same integer values (0-3).
-  // learning_steps was added in ts-fsrs v5; we don't persist it yet, so default to 0.
   const base: FsrsCard = {
     due: card.due,
     stability: card.stability,
@@ -29,7 +28,7 @@ function toFsrsCard(card: Card): FsrsCard {
     scheduled_days: card.scheduledDays,
     reps: card.reps,
     lapses: card.lapses,
-    learning_steps: 0,
+    learning_steps: card.learningSteps,
     state: card.state as unknown as FsrsCard["state"],
   };
   if (card.lastReview !== undefined) {
@@ -60,6 +59,7 @@ function applyFsrsCard(card: Card, fsrsCard: FsrsCard): Card {
     scheduledDays: fsrsCard.scheduled_days,
     reps: fsrsCard.reps,
     lapses: fsrsCard.lapses,
+    learningSteps: fsrsCard.learning_steps,
     // exactOptionalPropertyTypes: conditionally include to avoid `undefined` assignment
     ...(fsrsCard.last_review !== undefined ? { lastReview: fsrsCard.last_review } : {}),
   };
@@ -123,6 +123,7 @@ export function createCard(
     scheduledDays: emptyCard.scheduled_days,
     reps: emptyCard.reps,
     lapses: emptyCard.lapses,
+    learningSteps: emptyCard.learning_steps,
     // last_review is undefined on a new card — omit to satisfy exactOptionalPropertyTypes
     ...(emptyCard.last_review !== undefined ? { lastReview: emptyCard.last_review } : {}),
     ...(tag !== undefined ? { tag } : {}),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,8 @@ export interface Card {
   scheduledDays: number;
   reps: number;
   lapses: number;
+  /** ts-fsrs v5: index into the learning_steps sequence (0 = start of learning queue) */
+  learningSteps: number;
   lastReview?: Date;
 }
 

--- a/packages/db/migrations/0009_cards_learning_steps.sql
+++ b/packages/db/migrations/0009_cards_learning_steps.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `cards` ADD `learning_steps` integer DEFAULT 0 NOT NULL;

--- a/packages/db/migrations/meta/0009_snapshot.json
+++ b/packages/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,637 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d7586871-5f7a-4348-9980-17410f4b838c",
+  "prevId": "d7586871-5f7a-4348-9980-17410f4b838c",
+  "tables": {
+    "cards": {
+      "name": "cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'morph_form'"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "cards_due_idx": {
+          "name": "cards_due_idx",
+          "columns": [
+            "due"
+          ],
+          "isUnique": false
+        },
+        "cards_note_id_idx": {
+          "name": "cards_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cards_note_id_notes_id_fk": {
+          "name": "cards_note_id_notes_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lemmas": {
+      "name": "lemmas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'morfeusz'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_prompt": {
+          "name": "image_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "morph_forms": {
+      "name": "morph_forms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orth": {
+          "name": "orth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parsed_tag": {
+          "name": "parsed_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_path": {
+          "name": "audio_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "morph_forms_lemma_id_idx": {
+          "name": "morph_forms_lemma_id_idx",
+          "columns": [
+            "lemma_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "morph_forms_lemma_id_lemmas_id_fk": {
+          "name": "morph_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "morph_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "front": {
+          "name": "front",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "back": {
+          "name": "back",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_lemma_id_idx": {
+          "name": "notes_lemma_id_idx",
+          "columns": [
+            "lemma_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notes_lemma_id_lemmas_id_fk": {
+          "name": "notes_lemma_id_lemmas_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_before": {
+          "name": "state_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due": {
+          "name": "due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability_after": {
+          "name": "stability_after",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty_after": {
+          "name": "difficulty_after",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_card_id_idx": {
+          "name": "reviews_card_id_idx",
+          "columns": [
+            "card_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_card_id_cards_id_fk": {
+          "name": "reviews_card_id_cards_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vocab_list_notes": {
+      "name": "vocab_list_notes",
+      "columns": {
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vocab_list_notes_list_id_vocab_lists_id_fk": {
+          "name": "vocab_list_notes_list_id_vocab_lists_id_fk",
+          "tableFrom": "vocab_list_notes",
+          "tableTo": "vocab_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vocab_list_notes_note_id_notes_id_fk": {
+          "name": "vocab_list_notes_note_id_notes_id_fk",
+          "tableFrom": "vocab_list_notes",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vocab_list_notes_list_id_note_id_pk": {
+          "columns": [
+            "list_id",
+            "note_id"
+          ],
+          "name": "vocab_list_notes_list_id_note_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vocab_lists": {
+      "name": "vocab_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1772837030557,
       "tag": "0008_overjoyed_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1772840220037,
+      "tag": "0009_cards_learning_steps",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -138,6 +138,8 @@ export const cards = sqliteTable(
     scheduledDays: integer("scheduled_days").notNull().default(0),
     reps:          integer("reps").notNull().default(0),
     lapses:        integer("lapses").notNull().default(0),
+    /** ts-fsrs v5: position in the learning_steps sequence (0 = start of queue) */
+    learningSteps: integer("learning_steps").notNull().default(0),
     /** Unix timestamp (seconds), nullable */
     lastReview:    integer("last_review"),
   },


### PR DESCRIPTION
## Problem

ts-fsrs v5 tracks a card's position within its intra-day learning queue via `learning_steps`. Default learning steps are `["1m", "10m"]` for new cards and `["10m"]` for relearning.

Without persisting this field, every review of a New or Relearning card restarts at `learning_steps = 0`, so cards never progress through the queue correctly — they jump straight to long-term SRS on the next review instead of cycling through the 1m → 10m warm-up steps.

## Changes

**`packages/core/src/types.ts`**
Add `learningSteps: number` to `Card` interface.

**`packages/core/src/scheduler.ts`**
- `toFsrsCard`: pass `card.learningSteps` instead of hardcoded `0`
- `applyFsrsCard`: capture `fsrsCard.learning_steps → learningSteps`
- `createCard`: capture `emptyCard.learning_steps → learningSteps`

**`packages/db/src/schema.ts`**
Add `learning_steps integer NOT NULL DEFAULT 0` column to `cards`.

**`packages/db/migrations/0009_cards_learning_steps.sql`**
Single-line migration: `ALTER TABLE cards ADD learning_steps integer DEFAULT 0 NOT NULL`

**`packages/db/migrations/meta/0009_snapshot.json`**
Correct current-state Drizzle snapshot — also repairs the broken snapshot chain from migrations 0007 and 0008 (whose snapshot files were never committed to main). Future `drizzle-kit generate` calls will now produce a clean no-op diff, confirming the chain is correct.

**`packages/api/src/router.ts`**
- `insertCardValues`: persist `learningSteps`
- `sessionReview` handler: read `learningSteps` from DB row; write updated value back after scheduling
- `sessionDue` handler: populate `learningSteps` when constructing domain `Card` for `getNextReviewDates`

**`packages/core/src/scheduler.test.ts`**
Assert `learningSteps === 0` on a freshly created card.

## Tests

34 scheduler tests + 44 morph parser tests, all passing.