### PR TITLE
fix(web): mnemonic images fill container width on detail/quiz pages

### DIFF
--- a/packages/web/src/routes/notes/[id].tsx
+++ b/packages/web/src/routes/notes/[id].tsx
@@ -268,7 +268,7 @@ export default function NoteDetail() {
                           <img
                             src={url()}
                             alt={`Mnemonic for ${data().lemmaText ?? ''}`}
-                            class={css({ maxW: '160px', w: 'auto', h: 'auto', borderRadius: 'l2', border: '1px solid', borderColor: 'border' })}
+                            class={css({ w: '100%', h: 'auto', borderRadius: 'l2', border: '1px solid', borderColor: 'border' })}
                           />
                           <p class={css({ fontSize: 'xs', color: 'fg.subtle', mt: '1' })}>Mnemonic</p>
                         </div>

--- a/packages/web/src/routes/quiz/index.tsx
+++ b/packages/web/src/routes/quiz/index.tsx
@@ -744,7 +744,7 @@ export default function Quiz() {
                         src={url()}
                         alt="mnemonic"
                         class={css({
-                          maxW: '240px', w: 'auto', h: 'auto',
+                          w: '100%', h: 'auto',
                           borderRadius: 'l2',
                           border: '1px solid', borderColor: 'border',
                           mb: '4', display: 'block',


### PR DESCRIPTION
## What

Remove hardcoded `maxW` constraints on mnemonic images in the notes detail and quiz views:

- `notes/[id].tsx`: was `maxW: '160px'` → now `w: '100%', h: 'auto'`
- `quiz/index.tsx`: was `maxW: '240px'` → now `w: '100%', h: 'auto'`

`lemmas/[id].tsx` was already using `w: '100%'` and is unchanged.

## Why

The small fixed `maxW` values were constraining the mnemonic images to a tiny fraction of the available space on detail and quiz pages. The images now fill the container width and preserve their aspect ratio, consistent with the lemma detail page.

Images in tables/lists (none currently rendered) can use a smaller `maxW` at that point.