### PR TITLE
feat(api,cli): add review queue for draft contextual notes

### DIFF
--- a/packages/api/src/generation/generate.ts
+++ b/packages/api/src/generation/generate.ts
@@ -60,6 +60,67 @@ function insertCardValues(cardData: Omit<import("@strus/core").Card, "id">) {
 }
 
 // ---------------------------------------------------------------------------
+// createCardsForNote — shared helper (idempotent)
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert FSRS cards for an approved note.
+ * - cloze  → one cloze_fill card per gap
+ * - choice → one multiple_choice card
+ * - error  → one error_correction card
+ * - classifier → one classify card
+ *
+ * Returns the number of cards actually created (0 if they already exist).
+ */
+export async function createCardsForNote(
+  db: DbClient,
+  note: { id: string; kind: string },
+  gaps?: Array<{ id: string }>,
+): Promise<number> {
+  // Check idempotency — skip if any card already exists for this note
+  const existing = db
+    .select({ id: cards.id })
+    .from(cards)
+    .where(eq(cards.noteId, note.id))
+    .limit(1)
+    .all();
+
+  if (existing.length > 0) return 0;
+
+  let created = 0;
+
+  if (note.kind === "cloze") {
+    // Fetch gaps if not provided
+    const gapRows = gaps ?? db
+      .select({ id: clozeGaps.id })
+      .from(clozeGaps)
+      .where(eq(clozeGaps.noteId, note.id))
+      .all();
+
+    for (const gap of gapRows) {
+      const cardData = createCard(note.id, "cloze_fill");
+      db.insert(cards).values({
+        ...insertCardValues(cardData),
+        id: randomUUID(),
+        gapId: gap.id,
+      }).run();
+      created++;
+    }
+  } else if (note.kind === "choice") {
+    db.insert(cards).values(insertCardValues(createCard(note.id, "multiple_choice"))).run();
+    created++;
+  } else if (note.kind === "error") {
+    db.insert(cards).values(insertCardValues(createCard(note.id, "error_correction"))).run();
+    created++;
+  } else if (note.kind === "classifier") {
+    db.insert(cards).values(insertCardValues(createCard(note.id, "classify"))).run();
+    created++;
+  }
+
+  return created;
+}
+
+// ---------------------------------------------------------------------------
 // Few-shot example fetcher
 // ---------------------------------------------------------------------------
 
@@ -175,7 +236,8 @@ async function generateCloze(opts: {
     updatedAt: now,
   }).run();
 
-  // 7. Insert gaps (and cards if approved)
+  // 7. Insert gaps
+  const insertedGaps: Array<{ id: string }> = [];
   for (const gap of result.gaps) {
     const gapId = randomUUID();
     db.insert(clozeGaps).values({
@@ -189,15 +251,12 @@ async function generateCloze(opts: {
       explanation: gap.explanation,
       createdAt: now,
     }).run();
+    insertedGaps.push({ id: gapId });
+  }
 
-    if (status === "approved") {
-      const cardData = createCard(noteId, "cloze_fill");
-      db.insert(cards).values({
-        ...insertCardValues(cardData),
-        id: randomUUID(),
-        gapId,
-      }).run();
-    }
+  // 8. Create cards if approved
+  if (status === "approved") {
+    await createCardsForNote(db, { id: noteId, kind: "cloze" }, insertedGaps);
   }
 
   return status;
@@ -283,9 +342,9 @@ async function generateChoice(opts: {
     }).run();
   }
 
-  // Insert card if approved
+  // Create card if approved
   if (status === "approved") {
-    db.insert(cards).values(insertCardValues(createCard(noteId, "multiple_choice"))).run();
+    await createCardsForNote(db, { id: noteId, kind: "choice" });
   }
 
   return status;

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -6,7 +6,7 @@ import pkg from "../package.json" with { type: "json" };
 import { count, eq, lte, ne, like, and, or, inArray, asc, sql, isNull } from "drizzle-orm";
 import { db } from "@strus/db";
 import { createProvider } from "./generation/provider.js";
-import { generateBatch } from "./generation/generate.js";
+import { generateBatch, createCardsForNote } from "./generation/generate.js";
 import {
   vocabLists,
   lemmas,
@@ -2913,6 +2913,254 @@ const generationGenerate = os
   });
 
 // ---------------------------------------------------------------------------
+// notes.listDrafts — GET /notes/drafts
+// ---------------------------------------------------------------------------
+
+const notesListDrafts = os
+  .route({
+    method: "GET",
+    path: "/notes/drafts",
+    tags: ["Notes"],
+    summary: "List notes by status",
+    description: "Fetches notes (draft/flagged/approved/rejected) with their gaps or options included. Supports filtering by status, kind, and batchId.",
+  })
+  .input(
+    z.object({
+      status: z.enum(["draft", "flagged", "approved", "rejected"]).optional().describe("Filter by note status; omit for all statuses"),
+      kind: z.enum(["cloze", "choice", "error", "classifier"]).optional().describe("Filter by note kind"),
+      batchId: z.string().optional().describe("Filter by generation batch ID (matches generation_meta.batchId)"),
+      limit: z.number().int().min(1).max(100).default(20).describe("Maximum notes to return"),
+      offset: z.number().int().min(0).default(0).describe("Pagination offset"),
+    }),
+  )
+  .output(
+    z.object({
+      notes: z.array(
+        z.object({
+          id: z.string(),
+          kind: z.string(),
+          status: z.string(),
+          conceptId: z.string().nullable(),
+          sentenceId: z.string().nullable(),
+          explanation: z.string().nullable(),
+          generationMeta: z.string().nullable(),
+          createdAt: z.number(),
+          gaps: z.array(
+            z.object({
+              id: z.string(),
+              gapIndex: z.number(),
+              correctAnswers: z.string(),
+              hint: z.string().nullable(),
+              explanation: z.string().nullable(),
+            }),
+          ).optional(),
+          options: z.array(
+            z.object({
+              id: z.string(),
+              optionText: z.string(),
+              isCorrect: z.boolean(),
+              explanation: z.string().nullable(),
+            }),
+          ).optional(),
+          sentenceText: z.string().nullable().optional(),
+        }),
+      ),
+      total: z.number(),
+    }),
+  )
+  .handler(async ({ input }) => {
+    // Build filter conditions
+    const conditions: ReturnType<typeof eq>[] = [];
+    if (input.status) conditions.push(eq(notes.status, input.status));
+    if (input.kind) conditions.push(eq(notes.kind, input.kind));
+
+    // Fetch notes (with batchId filter applied in-memory since SQLite JSON extract is fragile)
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    let rows = db
+      .select({
+        id: notes.id,
+        kind: notes.kind,
+        status: notes.status,
+        conceptId: notes.conceptId,
+        sentenceId: notes.sentenceId,
+        explanation: notes.explanation,
+        generationMeta: notes.generationMeta,
+        createdAt: notes.createdAt,
+        sentenceText: sentences.text,
+      })
+      .from(notes)
+      .leftJoin(sentences, eq(sentences.id, notes.sentenceId))
+      .where(whereClause)
+      .all();
+
+    // Filter by batchId in-memory
+    if (input.batchId) {
+      const batchId = input.batchId;
+      rows = rows.filter((r) => {
+        if (!r.generationMeta) return false;
+        try {
+          const meta = JSON.parse(r.generationMeta) as { batchId?: string };
+          return meta.batchId === batchId;
+        } catch {
+          return false;
+        }
+      });
+    }
+
+    const total = rows.length;
+    const pageRows = rows.slice(input.offset, input.offset + input.limit);
+
+    // Fetch gaps and options for the page
+    const noteIds = pageRows.map((r) => r.id);
+
+    const gapRows = noteIds.length > 0
+      ? db
+        .select({
+          id: clozeGaps.id,
+          noteId: clozeGaps.noteId,
+          gapIndex: clozeGaps.gapIndex,
+          correctAnswers: clozeGaps.correctAnswers,
+          hint: clozeGaps.hint,
+          explanation: clozeGaps.explanation,
+        })
+        .from(clozeGaps)
+        .where(inArray(clozeGaps.noteId, noteIds))
+        .all()
+      : [];
+
+    const optionRows = noteIds.length > 0
+      ? db
+        .select({
+          id: choiceOptions.id,
+          noteId: choiceOptions.noteId,
+          optionText: choiceOptions.optionText,
+          isCorrect: choiceOptions.isCorrect,
+          explanation: choiceOptions.explanation,
+        })
+        .from(choiceOptions)
+        .where(inArray(choiceOptions.noteId, noteIds))
+        .all()
+      : [];
+
+    // Group by noteId
+    const gapsByNote = new Map<string, typeof gapRows>();
+    for (const g of gapRows) {
+      const existing = gapsByNote.get(g.noteId) ?? [];
+      existing.push(g);
+      gapsByNote.set(g.noteId, existing);
+    }
+
+    const optionsByNote = new Map<string, typeof optionRows>();
+    for (const o of optionRows) {
+      const existing = optionsByNote.get(o.noteId) ?? [];
+      existing.push(o);
+      optionsByNote.set(o.noteId, existing);
+    }
+
+    const resultNotes = pageRows.map((r) => ({
+      id: r.id,
+      kind: r.kind,
+      status: r.status,
+      conceptId: r.conceptId,
+      sentenceId: r.sentenceId,
+      explanation: r.explanation,
+      generationMeta: r.generationMeta,
+      createdAt: r.createdAt instanceof Date ? Math.floor(r.createdAt.getTime() / 1000) : (r.createdAt as number),
+      sentenceText: r.sentenceText ?? null,
+      gaps: r.kind === "cloze" ? (gapsByNote.get(r.id) ?? []).map((g) => ({
+        id: g.id,
+        gapIndex: g.gapIndex,
+        correctAnswers: g.correctAnswers,
+        hint: g.hint,
+        explanation: g.explanation,
+      })) : undefined,
+      options: r.kind === "choice" ? (optionsByNote.get(r.id) ?? []).map((o) => ({
+        id: o.id,
+        optionText: o.optionText,
+        isCorrect: o.isCorrect,
+        explanation: o.explanation,
+      })) : undefined,
+    }));
+
+    return { notes: resultNotes, total };
+  });
+
+// ---------------------------------------------------------------------------
+// notes.review — POST /notes/review
+// ---------------------------------------------------------------------------
+
+const notesReview = os
+  .route({
+    method: "POST",
+    path: "/notes/review",
+    tags: ["Notes"],
+    summary: "Approve, flag, or reject a draft note",
+    description: "Transitions a note's status. On approve, FSRS cards are auto-created. Idempotent — re-approving a note that already has cards is safe.",
+  })
+  .input(
+    z.object({
+      noteId: z.string().uuid().describe("ID of the note to review"),
+      action: z.enum(["approve", "flag", "reject"]).describe("Triage action"),
+      reason: z.string().optional().describe("Optional human annotation for flag/reject actions"),
+    }),
+  )
+  .output(
+    z.object({
+      noteId: z.string(),
+      status: z.string(),
+      cardsCreated: z.number(),
+    }),
+  )
+  .handler(async ({ input }) => {
+    const [note] = db
+      .select()
+      .from(notes)
+      .where(eq(notes.id, input.noteId))
+      .limit(1)
+      .all();
+
+    if (!note) {
+      throw new ORPCError("NOT_FOUND", { message: `Note not found: ${input.noteId}` });
+    }
+
+    const statusMap = {
+      approve: "approved",
+      flag: "flagged",
+      reject: "rejected",
+    } as const;
+
+    const newStatus = statusMap[input.action];
+    const now = new Date();
+
+    // Optionally append reason to generation_meta
+    let updatedMeta = note.generationMeta;
+    if (input.reason && (input.action === "flag" || input.action === "reject")) {
+      try {
+        const meta = updatedMeta ? (JSON.parse(updatedMeta) as Record<string, unknown>) : {};
+        meta["reviewReason"] = input.reason;
+        meta["reviewedAt"] = now.toISOString();
+        updatedMeta = JSON.stringify(meta);
+      } catch {
+        // If meta is malformed, just append a new object
+        updatedMeta = JSON.stringify({ reviewReason: input.reason, reviewedAt: now.toISOString() });
+      }
+    }
+
+    db.update(notes)
+      .set({ status: newStatus, generationMeta: updatedMeta, updatedAt: now })
+      .where(eq(notes.id, input.noteId))
+      .run();
+
+    let cardsCreated = 0;
+    if (input.action === "approve") {
+      cardsCreated = await createCardsForNote(db, { id: note.id, kind: note.kind });
+    }
+
+    return { noteId: input.noteId, status: newStatus, cardsCreated };
+  });
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
@@ -2946,6 +3194,8 @@ export const router = {
     createChoice: notesCreateChoice,
     createError: notesCreateError,
     createClassifier: notesCreateClassifier,
+    listDrafts: notesListDrafts,
+    review: notesReview,
   },
   lemmas: {
     list: lemmasList,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1119,6 +1119,240 @@ generateCmd
   );
 
 // ---------------------------------------------------------------------------
+// strus review — human triage for LLM-generated notes
+// ---------------------------------------------------------------------------
+
+interface DraftNote {
+  id: string;
+  kind: string;
+  status: string;
+  conceptId: string | null;
+  sentenceId: string | null;
+  explanation: string | null;
+  generationMeta: string | null;
+  createdAt: number;
+  sentenceText?: string | null;
+  gaps?: Array<{
+    id: string;
+    gapIndex: number;
+    correctAnswers: string;
+    hint: string | null;
+    explanation: string | null;
+  }>;
+  options?: Array<{
+    id: string;
+    optionText: string;
+    isCorrect: boolean;
+    explanation: string | null;
+  }>;
+}
+
+function parseMeta(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try { return JSON.parse(raw) as Record<string, unknown>; } catch { return {}; }
+}
+
+function renderNote(note: DraftNote, index: number, total: number): void {
+  const meta = parseMeta(note.generationMeta);
+  const batchId = (meta["batchId"] as string | undefined) ?? "(none)";
+  const validationResults = (meta["validationResults"] as Array<{ layer: string; pass: boolean }> | undefined) ?? [];
+
+  console.log("\n" + "─".repeat(45));
+  console.log(`Note #${index} of ${total}  [${note.kind} | ${note.status}]`);
+  console.log(`Concept: ${note.conceptId ?? "(none)"}`);
+  console.log(`Batch:   ${batchId}`);
+
+  if (note.sentenceText) {
+    console.log(`\nSentence: "${note.sentenceText}"`);
+  }
+
+  if (note.kind === "cloze" && note.gaps && note.gaps.length > 0) {
+    for (const gap of note.gaps) {
+      const answers = (() => {
+        try { return JSON.stringify(JSON.parse(gap.correctAnswers)); }
+        catch { return gap.correctAnswers; }
+      })();
+      console.log(`\nGap ${gap.gapIndex}:`);
+      console.log(`  Correct answers: ${answers}`);
+      if (gap.hint) console.log(`  Hint: ${gap.hint}`);
+      if (gap.explanation) console.log(`  Explanation: ${gap.explanation}`);
+    }
+  } else if (note.kind === "choice" && note.options && note.options.length > 0) {
+    // For choice notes, front is stored in the note itself — fetch from notes API if needed
+    console.log(`\nOptions:`);
+    for (const opt of note.options) {
+      const marker = opt.isCorrect ? "✓" : " ";
+      console.log(`  [${marker}] ${opt.optionText}${opt.explanation ? `  — ${opt.explanation}` : ""}`);
+    }
+  }
+
+  if (note.explanation) {
+    console.log(`\nExplanation: ${note.explanation}`);
+  }
+
+  if (validationResults.length > 0) {
+    const validationStr = validationResults
+      .map((r) => `${r.layer} ${r.pass ? "✓" : "✗"}`)
+      .join(" | ");
+    console.log(`\nValidation: ${validationStr}`);
+  }
+
+  console.log("─".repeat(45));
+  process.stdout.write("[a]pprove  [f]lag  [r]eject  [s]kip  [q]uit\n> ");
+}
+
+/** Read a single keypress from stdin (raw mode). Returns the key character. */
+function readKeypress(): Promise<string> {
+  return new Promise((resolve) => {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+    const onData = (key: string) => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stdin.removeListener("data", onData);
+      resolve(key);
+    };
+    process.stdin.on("data", onData);
+  });
+}
+
+const reviewCmd = program
+  .command("review")
+  .description("Triage LLM-generated draft notes (approve/flag/reject)");
+
+// `strus review` — interactive mode
+reviewCmd
+  .command("queue", { isDefault: true })
+  .description("Interactive triage: walk through draft notes one by one")
+  .option("--batch <id>", "Filter by generation batch ID")
+  .option("--kind <kind>", "Filter by note kind (cloze|choice|error|classifier)")
+  .option("--status <status>", "Filter by status (default: draft)", "draft")
+  .action(
+    async (opts: { batch?: string; kind?: string; status?: string }) => {
+      const qs = new URLSearchParams();
+      qs.set("limit", "100");
+      qs.set("offset", "0");
+      if (opts.status) qs.set("status", opts.status);
+      if (opts.kind) qs.set("kind", opts.kind);
+      if (opts.batch) qs.set("batchId", opts.batch);
+
+      const result = await apiGet<{ notes: DraftNote[]; total: number }>(
+        `/api/notes/drafts?${qs.toString()}`,
+      );
+
+      const queue = result.notes;
+
+      if (queue.length === 0) {
+        console.log(`No notes found with status="${opts.status ?? "draft"}".`);
+        return;
+      }
+
+      let approved = 0;
+      let flagged = 0;
+      let rejected = 0;
+      let skipped = 0;
+      let reviewedCount = 0;
+      let quit = false;
+
+      for (const [idx, note] of queue.entries()) {
+        if (quit) break;
+        renderNote(note, idx + 1, queue.length);
+
+        let handled = false;
+        while (!handled) {
+          const key = (await readKeypress()).toLowerCase();
+          process.stdout.write("\n");
+
+          if (key === "q" || key === "\u0003" /* Ctrl-C */) {
+            console.log("Quitting triage...");
+            quit = true;
+            handled = true;
+            break;
+          }
+
+          if (key === "s") {
+            skipped++;
+            handled = true;
+            break;
+          }
+
+          let action: "approve" | "flag" | "reject" | null = null;
+          if (key === "a") action = "approve";
+          else if (key === "f") action = "flag";
+          else if (key === "r") action = "reject";
+
+          if (action) {
+            try {
+              const res = await apiPost<{ noteId: string; status: string; cardsCreated: number }>(
+                "/api/notes/review",
+                { noteId: note.id, action },
+              );
+              console.log(
+                `→ ${res.status}${action === "approve" && res.cardsCreated > 0 ? ` (${res.cardsCreated} card(s) created)` : ""}`,
+              );
+              reviewedCount++;
+              if (action === "approve") approved++;
+              else if (action === "flag") flagged++;
+              else if (action === "reject") rejected++;
+            } catch (err) {
+              console.error(`API error: ${String(err)}`);
+            }
+            handled = true;
+          } else {
+            process.stdout.write("Unknown key. Use [a]pprove [f]lag [r]eject [s]kip [q]uit\n> ");
+          }
+        }
+      }
+
+      console.log(
+        `\nSession complete. Reviewed: ${reviewedCount} | Approved: ${approved} | Flagged: ${flagged} | Rejected: ${rejected} | Skipped: ${skipped}`,
+      );
+    },
+  );
+
+// `strus review stats` — non-interactive counts
+reviewCmd
+  .command("stats")
+  .description("Show note counts by status")
+  .option("--batch <id>", "Filter by generation batch ID")
+  .action(async (opts: { batch?: string }) => {
+    const qs = new URLSearchParams();
+    qs.set("limit", "1000");
+    qs.set("offset", "0");
+    if (opts.batch) qs.set("batchId", opts.batch);
+
+    const result = await apiGet<{ notes: DraftNote[]; total: number }>(
+      `/api/notes/drafts?${qs.toString()}`,
+    );
+
+    const counts: Record<string, number> = {};
+    for (const note of result.notes) {
+      counts[note.status] = (counts[note.status] ?? 0) + 1;
+    }
+
+    const statuses = ["draft", "approved", "flagged", "rejected"];
+    const total = result.notes.length;
+
+    console.log(`\n${"Status".padEnd(12)}${"Count".padStart(6)}`);
+    console.log("─".repeat(12) + "  " + "─".repeat(5));
+    for (const s of statuses) {
+      if (counts[s] !== undefined) {
+        console.log(`${s.padEnd(12)}${String(counts[s]).padStart(6)}`);
+      }
+    }
+    // Any statuses not in the standard list
+    for (const [s, c] of Object.entries(counts)) {
+      if (!statuses.includes(s)) {
+        console.log(`${s.padEnd(12)}${String(c).padStart(6)}`);
+      }
+    }
+    console.log("─".repeat(12) + "  " + "─".repeat(5));
+    console.log(`${"total".padEnd(12)}${String(total).padStart(6)}`);
+    console.log();
+  });
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Phase 4: human triage layer for LLM-generated exercise content.

## New API
- `GET /api/notes/drafts` — list notes by status/kind/batchId with gaps/options included
- `POST /api/notes/review` — approve/flag/reject; auto-creates cards on approve

## New CLI
- `strus review` — interactive single-keypress triage; shows sentence, gaps/options, validation results
- `strus review stats` — non-interactive counts by status

## Refactor
- `createCardsForNote()` extracted from `generate.ts` and shared with review handler (idempotent)