### PR TITLE
feat(api,cli): semantic clusters with distractor sourcing

### DIFF
--- a/packages/api/src/generation/generate.ts
+++ b/packages/api/src/generation/generate.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import Mustache from "mustache";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import {
   grammarConcepts,
   sentences,
@@ -10,6 +10,8 @@ import {
   cards,
   clozeGaps,
   choiceOptions,
+  semanticClusterMembers,
+  lemmas,
 } from "@strus/db";
 import type { DbClient } from "@strus/db";
 import { createCard } from "@strus/core";
@@ -263,6 +265,54 @@ async function generateCloze(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// getClusterSiblings — fetch lemma strings from the same clusters
+// ---------------------------------------------------------------------------
+
+async function getClusterSiblings(
+  db: DbClient,
+  lemmaId: string,
+  limit: number,
+): Promise<string[]> {
+  // Find all clusters this lemma belongs to
+  const memberRows = db
+    .select({ clusterId: semanticClusterMembers.clusterId })
+    .from(semanticClusterMembers)
+    .where(eq(semanticClusterMembers.lemmaId, lemmaId))
+    .all();
+
+  if (memberRows.length === 0) return [];
+
+  const clusterIds = memberRows.map((r) => r.clusterId);
+
+  // Fetch all other members from those clusters
+  const siblingRows = db
+    .select({ lemmaId: semanticClusterMembers.lemmaId })
+    .from(semanticClusterMembers)
+    .where(inArray(semanticClusterMembers.clusterId, clusterIds))
+    .all()
+    .filter((r) => r.lemmaId !== lemmaId);
+
+  if (siblingRows.length === 0) return [];
+
+  const siblingLemmaIds = [...new Set(siblingRows.map((r) => r.lemmaId))];
+
+  // Fetch actual lemma strings
+  const lemmaRows = db
+    .select({ id: lemmas.id, lemma: lemmas.lemma })
+    .from(lemmas)
+    .where(inArray(lemmas.id, siblingLemmaIds))
+    .all();
+
+  // Shuffle and cap
+  const shuffled = lemmaRows
+    .map((l) => ({ sort: Math.random(), lemma: l.lemma }))
+    .sort((a, b) => a.sort - b.sort)
+    .map((l) => l.lemma);
+
+  return shuffled.slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
 // generateChoice — one choice note + options + card
 // ---------------------------------------------------------------------------
 
@@ -274,10 +324,25 @@ async function generateChoice(opts: {
 }): Promise<"approved" | "flagged"> {
   const { db, concept, batchId, provider } = opts;
 
-  // Render template (no few-shot for choice in this phase)
+  // Find cluster siblings from the concept's lemma (if concept has an associated note with a lemma)
+  const conceptNoteRows = db
+    .select({ lemmaId: notes.lemmaId })
+    .from(notes)
+    .where(and(eq(notes.conceptId, concept.id)))
+    .all()
+    .filter((n) => n.lemmaId !== null);
+
+  let clusterDistractors: string[] = [];
+  if (conceptNoteRows.length > 0) {
+    const firstLemmaId = conceptNoteRows[0]!.lemmaId as string;
+    clusterDistractors = await getClusterSiblings(db, firstLemmaId, 5);
+  }
+
+  // Render template
   const prompt = renderTemplate("choice-v1.txt", {
     concept_name: concept.name,
     sentence_context: null,
+    cluster_distractors: clusterDistractors.length > 0 ? clusterDistractors : null,
   });
 
   // Generate

--- a/packages/api/src/generation/templates/choice-v1.txt
+++ b/packages/api/src/generation/templates/choice-v1.txt
@@ -5,6 +5,12 @@ Base this question on the following sentence:
 {{sentence_context}}
 {{/sentence_context}}
 
+{{#cluster_distractors}}
+Real confusable words from the same semantic cluster (prefer these as wrong options):
+{{#.}}- {{.}}
+{{/.}}
+{{/cluster_distractors}}
+
 Provide exactly 4 options: 1 correct, 3 plausible but clearly wrong.
 The wrong options must be definitively incorrect — not "could also work in some contexts".
 

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -20,8 +20,10 @@ import {
   sentenceConcepts,
   clozeGaps,
   choiceOptions,
+  semanticClusters,
+  semanticClusterMembers,
 } from "@strus/db";
-import { generate, parseTag, tagGender, analyseText } from "@strus/morph";
+import { generate, parseTag, tagGender, analyseText, analyse } from "@strus/morph";
 import { generateAudio, generateImage, getMediaBaseUrl } from "./media.js";
 import { getSetting, setSetting, SETTINGS_KEYS, DEFAULTS } from "./settings.js";
 import {
@@ -2860,6 +2862,383 @@ const settingsSet = os
   });
 
 // ---------------------------------------------------------------------------
+// Semantic Cluster procedures
+// ---------------------------------------------------------------------------
+
+const ClusterOutput = z.object({
+  id: zId,
+  name: z.string(),
+  clusterType: z.string(),
+  description: z.string().nullable(),
+  createdAt: zIso,
+});
+
+const clustersCreate = os
+  .route({
+    method: "POST",
+    path: "/clusters",
+    tags: ["Clusters"],
+    summary: "Create a semantic cluster",
+  })
+  .input(z.object({
+    name: z.string().min(1).describe("Cluster name, e.g. 'motion verbs'"),
+    clusterType: z.string().min(1).describe("Cluster type: prefix_family | vom_group | aspect_pair | custom"),
+    description: z.string().optional().describe("Optional description"),
+  }))
+  .output(z.object({ id: zId, name: z.string() }))
+  .handler(async ({ input }) => {
+    const id = crypto.randomUUID();
+    const now = new Date();
+    db.insert(semanticClusters).values({
+      id,
+      name: input.name,
+      clusterType: input.clusterType,
+      description: input.description ?? null,
+      createdAt: now,
+    }).run();
+    return { id, name: input.name };
+  });
+
+const clustersList = os
+  .route({
+    method: "GET",
+    path: "/clusters",
+    tags: ["Clusters"],
+    summary: "List semantic clusters",
+  })
+  .input(z.object({
+    limit: z.number().int().min(1).max(100).default(50),
+    offset: z.number().int().min(0).default(0),
+  }))
+  .output(z.object({
+    clusters: z.array(z.object({
+      id: zId,
+      name: z.string(),
+      clusterType: z.string(),
+      description: z.string().nullable(),
+      memberCount: z.number(),
+    })),
+    total: z.number(),
+  }))
+  .handler(async ({ input }) => {
+    const rows = db.select().from(semanticClusters)
+      .limit(input.limit)
+      .offset(input.offset)
+      .all();
+
+    const totalResult = db.select({ total: count() }).from(semanticClusters).all();
+    const total = totalResult[0]?.total ?? 0;
+
+    const clusters = rows.map((r) => {
+      const memberResult = db
+        .select({ memberCount: count() })
+        .from(semanticClusterMembers)
+        .where(eq(semanticClusterMembers.clusterId, r.id))
+        .all();
+      const memberCount = memberResult[0]?.memberCount ?? 0;
+      return {
+        id: r.id,
+        name: r.name,
+        clusterType: r.clusterType,
+        description: r.description,
+        memberCount,
+      };
+    });
+
+    return { clusters, total: total ?? 0 };
+  });
+
+const clustersGet = os
+  .route({
+    method: "GET",
+    path: "/clusters/{id}",
+    tags: ["Clusters"],
+    summary: "Get a semantic cluster with its members",
+  })
+  .input(z.object({ id: zId }))
+  .output(z.object({
+    id: zId,
+    name: z.string(),
+    clusterType: z.string(),
+    description: z.string().nullable(),
+    members: z.array(z.object({
+      lemmaId: zId,
+      lemma: z.string(),
+      pos: z.string().nullable(),
+    })),
+  }))
+  .handler(async ({ input }) => {
+    const [cluster] = db.select().from(semanticClusters)
+      .where(eq(semanticClusters.id, input.id))
+      .limit(1)
+      .all();
+    if (!cluster) throw new ORPCError("NOT_FOUND", { message: `Cluster not found: ${input.id}` });
+
+    const memberRows = db
+      .select({
+        lemmaId: semanticClusterMembers.lemmaId,
+        lemma: lemmas.lemma,
+        pos: lemmas.pos,
+      })
+      .from(semanticClusterMembers)
+      .innerJoin(lemmas, eq(lemmas.id, semanticClusterMembers.lemmaId))
+      .where(eq(semanticClusterMembers.clusterId, input.id))
+      .all();
+
+    return {
+      id: cluster.id,
+      name: cluster.name,
+      clusterType: cluster.clusterType,
+      description: cluster.description,
+      members: memberRows.map((m) => ({
+        lemmaId: m.lemmaId,
+        lemma: m.lemma,
+        pos: m.pos ?? null,
+      })),
+    };
+  });
+
+const clustersAddMember = os
+  .route({
+    method: "POST",
+    path: "/clusters/{clusterId}/members",
+    tags: ["Clusters"],
+    summary: "Add a lemma to a semantic cluster (idempotent)",
+  })
+  .input(z.object({
+    clusterId: zId,
+    lemmaId: zId,
+  }))
+  .output(z.object({ clusterId: zId, lemmaId: zId }))
+  .handler(async ({ input }) => {
+    // Verify cluster exists
+    const [cluster] = db.select({ id: semanticClusters.id }).from(semanticClusters)
+      .where(eq(semanticClusters.id, input.clusterId)).limit(1).all();
+    if (!cluster) throw new ORPCError("NOT_FOUND", { message: `Cluster not found: ${input.clusterId}` });
+
+    // Verify lemma exists
+    const [lemma] = db.select({ id: lemmas.id }).from(lemmas)
+      .where(eq(lemmas.id, input.lemmaId)).limit(1).all();
+    if (!lemma) throw new ORPCError("NOT_FOUND", { message: `Lemma not found: ${input.lemmaId}` });
+
+    // Idempotent insert — ignore if already exists
+    const existing = db.select().from(semanticClusterMembers)
+      .where(and(
+        eq(semanticClusterMembers.clusterId, input.clusterId),
+        eq(semanticClusterMembers.lemmaId, input.lemmaId),
+      ))
+      .limit(1)
+      .all();
+
+    if (existing.length === 0) {
+      db.insert(semanticClusterMembers).values({
+        clusterId: input.clusterId,
+        lemmaId: input.lemmaId,
+        role: null,
+      }).run();
+    }
+
+    return { clusterId: input.clusterId, lemmaId: input.lemmaId };
+  });
+
+const clustersRemoveMember = os
+  .route({
+    method: "DELETE",
+    path: "/clusters/{clusterId}/members/{lemmaId}",
+    tags: ["Clusters"],
+    summary: "Remove a lemma from a semantic cluster",
+  })
+  .input(z.object({
+    clusterId: zId,
+    lemmaId: zId,
+  }))
+  .output(z.object({ removed: z.boolean() }))
+  .handler(async ({ input }) => {
+    const existing = db.select().from(semanticClusterMembers)
+      .where(and(
+        eq(semanticClusterMembers.clusterId, input.clusterId),
+        eq(semanticClusterMembers.lemmaId, input.lemmaId),
+      ))
+      .limit(1)
+      .all();
+
+    if (existing.length === 0) return { removed: false };
+
+    db.delete(semanticClusterMembers)
+      .where(and(
+        eq(semanticClusterMembers.clusterId, input.clusterId),
+        eq(semanticClusterMembers.lemmaId, input.lemmaId),
+      ))
+      .run();
+
+    return { removed: true };
+  });
+
+const clustersSuggest = os
+  .route({
+    method: "GET",
+    path: "/clusters/suggest",
+    tags: ["Clusters"],
+    summary: "Suggest cluster candidates for a lemma",
+    description: "Pure DB scoring: same POS class (+0.4) + shared grammar concepts (+0.3 each, capped at +0.6) - already clustered (-0.1).",
+  })
+  .input(z.object({
+    lemmaId: zId,
+    limit: z.number().int().min(1).max(50).default(10),
+  }))
+  .output(z.object({
+    suggestions: z.array(z.object({
+      lemmaId: zId,
+      lemma: z.string(),
+      pos: z.string().nullable(),
+      score: z.number(),
+      reasons: z.array(z.string()),
+    })),
+  }))
+  .handler(async ({ input }) => {
+    // 1. Get target lemma
+    const [targetLemma] = db.select().from(lemmas)
+      .where(eq(lemmas.id, input.lemmaId))
+      .limit(1)
+      .all();
+    if (!targetLemma) throw new ORPCError("NOT_FOUND", { message: `Lemma not found: ${input.lemmaId}` });
+
+    // 2. Get POS class from Morfeusz2 analysis
+    let targetPosClass: string | null = null;
+    try {
+      const forms = await analyse(targetLemma.lemma);
+      if (forms.length > 0) {
+        const tag = forms[0]!.tag;
+        targetPosClass = tag.split(":")[0] ?? null;
+      }
+    } catch {
+      // Fallback to stored pos if Morfeusz2 fails
+      targetPosClass = targetLemma.pos ? targetLemma.pos.split(":")[0] ?? null : null;
+    }
+
+    // 3. Get grammar concepts for the target lemma (via notes.conceptId and sentence_concepts)
+    const targetNoteRows = db.select({ conceptId: notes.conceptId })
+      .from(notes)
+      .where(and(eq(notes.lemmaId, input.lemmaId)))
+      .all()
+      .filter((n) => n.conceptId !== null);
+    const targetConceptIds = new Set(targetNoteRows.map((n) => n.conceptId as string));
+
+    // Also pick up sentence_concepts linked via notes' sentences
+    const targetSentenceRows = db.select({ conceptId: sentenceConcepts.conceptId })
+      .from(sentenceConcepts)
+      .innerJoin(notes, eq(notes.sentenceId, sentenceConcepts.sentenceId))
+      .where(eq(notes.lemmaId, input.lemmaId))
+      .all();
+    for (const row of targetSentenceRows) {
+      targetConceptIds.add(row.conceptId);
+    }
+
+    // 4. Get clusters the target lemma is already in
+    const targetClusterRows = db.select({ clusterId: semanticClusterMembers.clusterId })
+      .from(semanticClusterMembers)
+      .where(eq(semanticClusterMembers.lemmaId, input.lemmaId))
+      .all();
+    const targetClusterIds = new Set(targetClusterRows.map((r) => r.clusterId));
+
+    // 5. Get all lemmas that share a cluster with the target (for -0.1 penalty)
+    const coClusteredLemmaIds = new Set<string>();
+    if (targetClusterIds.size > 0) {
+      const coRows = db.select({ lemmaId: semanticClusterMembers.lemmaId })
+        .from(semanticClusterMembers)
+        .where(inArray(semanticClusterMembers.clusterId, [...targetClusterIds]))
+        .all();
+      for (const r of coRows) {
+        if (r.lemmaId !== input.lemmaId) coClusteredLemmaIds.add(r.lemmaId);
+      }
+    }
+
+    // 6. Get all other lemmas
+    const allLemmas = db.select().from(lemmas)
+      .where(ne(lemmas.id, input.lemmaId))
+      .all();
+
+    // 7. Score each candidate
+    const scored: Array<{
+      lemmaId: string;
+      lemma: string;
+      pos: string | null;
+      score: number;
+      reasons: string[];
+    }> = [];
+
+    for (const candidate of allLemmas) {
+      let score = 0;
+      const reasons: string[] = [];
+
+      // POS class scoring
+      if (targetPosClass !== null) {
+        const candidatePosClass = candidate.pos ? candidate.pos.split(":")[0] ?? null : null;
+        if (candidatePosClass === targetPosClass) {
+          score += 0.4;
+          reasons.push("same POS class");
+        }
+      }
+
+      // Shared grammar concepts
+      const candidateNoteRows = db.select({ conceptId: notes.conceptId })
+        .from(notes)
+        .where(eq(notes.lemmaId, candidate.id))
+        .all()
+        .filter((n) => n.conceptId !== null);
+      const candidateConceptIds = new Set(candidateNoteRows.map((n) => n.conceptId as string));
+
+      const candidateSentenceRows = db.select({ conceptId: sentenceConcepts.conceptId })
+        .from(sentenceConcepts)
+        .innerJoin(notes, eq(notes.sentenceId, sentenceConcepts.sentenceId))
+        .where(eq(notes.lemmaId, candidate.id))
+        .all();
+      for (const row of candidateSentenceRows) {
+        candidateConceptIds.add(row.conceptId);
+      }
+
+      let conceptBonus = 0;
+      for (const cid of candidateConceptIds) {
+        if (targetConceptIds.has(cid)) {
+          // Look up concept name for reason string
+          const [concept] = db.select({ name: grammarConcepts.name })
+            .from(grammarConcepts)
+            .where(eq(grammarConcepts.id, cid))
+            .limit(1)
+            .all();
+          const bonus = Math.min(0.3, 0.6 - conceptBonus);
+          if (bonus > 0) {
+            conceptBonus += 0.3;
+            score += bonus;
+            reasons.push(`shares concept: ${concept?.name ?? cid}`);
+          }
+          if (conceptBonus >= 0.6) break;
+        }
+      }
+
+      // Penalty for already co-clustered
+      if (coClusteredLemmaIds.has(candidate.id)) {
+        score -= 0.1;
+        reasons.push("already in same cluster");
+      }
+
+      if (score > 0) {
+        scored.push({
+          lemmaId: candidate.id,
+          lemma: candidate.lemma,
+          pos: candidate.pos ?? null,
+          score: Math.max(0, Math.round(score * 100) / 100),
+          reasons,
+        });
+      }
+    }
+
+    // Sort descending by score, return top N
+    scored.sort((a, b) => b.score - a.score);
+    return { suggestions: scored.slice(0, input.limit) };
+  });
+
+// ---------------------------------------------------------------------------
 // Generation procedures
 // ---------------------------------------------------------------------------
 
@@ -3229,6 +3608,14 @@ export const router = {
   },
   generation: {
     generate: generationGenerate,
+  },
+  clusters: {
+    create: clustersCreate,
+    list: clustersList,
+    get: clustersGet,
+    addMember: clustersAddMember,
+    removeMember: clustersRemoveMember,
+    suggest: clustersSuggest,
   },
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1353,6 +1353,152 @@ reviewCmd
   });
 
 // ---------------------------------------------------------------------------
+// strus cluster
+// ---------------------------------------------------------------------------
+
+const clusterCmd = program
+  .command("cluster")
+  .description("Manage semantic clusters");
+
+// strus cluster create
+clusterCmd
+  .command("create")
+  .description("Create a new semantic cluster")
+  .requiredOption("--name <name>", "Cluster name (e.g. 'motion verbs')")
+  .option("--type <type>", "Cluster type (prefix_family|vom_group|aspect_pair|custom)", "custom")
+  .option("--description <desc>", "Optional description")
+  .action(async (opts: { name: string; type: string; description?: string }) => {
+    const result = await apiPost<{ id: string; name: string }>("/api/clusters", {
+      name: opts.name,
+      clusterType: opts.type,
+      description: opts.description,
+    });
+    console.log(`Created cluster: ${result.name} (${result.id})`);
+  });
+
+// strus cluster list
+clusterCmd
+  .command("list")
+  .description("List semantic clusters")
+  .option("--limit <n>", "Max results", "50")
+  .option("--offset <n>", "Offset", "0")
+  .action(async (opts: { limit: string; offset: string }) => {
+    const qs = new URLSearchParams({ limit: opts.limit, offset: opts.offset });
+    const result = await apiGet<{
+      clusters: Array<{ id: string; name: string; clusterType: string; description: string | null; memberCount: number }>;
+      total: number;
+    }>(`/api/clusters?${qs}`);
+
+    if (result.clusters.length === 0) {
+      console.log("No clusters found.");
+      return;
+    }
+
+    console.log(`\n${"Name".padEnd(30)}${"Type".padEnd(16)}${"Members".padStart(8)}  ID`);
+    console.log("─".repeat(75));
+    for (const c of result.clusters) {
+      console.log(
+        `${c.name.padEnd(30)}${c.clusterType.padEnd(16)}${String(c.memberCount).padStart(8)}  ${c.id}`,
+      );
+    }
+    console.log(`\nTotal: ${result.total}`);
+  });
+
+// strus cluster show <id>
+clusterCmd
+  .command("show <id>")
+  .description("Show a semantic cluster with its members")
+  .action(async (id: string) => {
+    const cluster = await apiGet<{
+      id: string;
+      name: string;
+      clusterType: string;
+      description: string | null;
+      members: Array<{ lemmaId: string; lemma: string; pos: string | null }>;
+    }>(`/api/clusters/${id}`);
+
+    console.log(`\nCluster: ${cluster.name}`);
+    console.log(`Type:    ${cluster.clusterType}`);
+    if (cluster.description) console.log(`Desc:    ${cluster.description}`);
+    console.log(`ID:      ${cluster.id}`);
+    console.log(`Members: ${cluster.members.length}`);
+
+    if (cluster.members.length > 0) {
+      console.log("\n  Lemma                   POS              ID");
+      console.log("  " + "─".repeat(65));
+      for (const m of cluster.members) {
+        console.log(`  ${m.lemma.padEnd(24)}${(m.pos ?? "—").padEnd(16)} ${m.lemmaId}`);
+      }
+    }
+    console.log();
+  });
+
+// strus cluster add-member
+clusterCmd
+  .command("add-member")
+  .description("Add a lemma to a semantic cluster")
+  .requiredOption("--cluster <id>", "Cluster ID")
+  .requiredOption("--lemma <id>", "Lemma ID")
+  .action(async (opts: { cluster: string; lemma: string }) => {
+    const result = await apiPost<{ clusterId: string; lemmaId: string }>(
+      `/api/clusters/${opts.cluster}/members`,
+      { clusterId: opts.cluster, lemmaId: opts.lemma },
+    );
+    console.log(`Added lemma ${result.lemmaId} to cluster ${result.clusterId}`);
+  });
+
+// strus cluster remove-member
+clusterCmd
+  .command("remove-member")
+  .description("Remove a lemma from a semantic cluster")
+  .requiredOption("--cluster <id>", "Cluster ID")
+  .requiredOption("--lemma <id>", "Lemma ID")
+  .action(async (opts: { cluster: string; lemma: string }) => {
+    const result = await apiDelete<{ removed: boolean }>(
+      `/api/clusters/${opts.cluster}/members/${opts.lemma}`,
+    );
+    console.log(result.removed ? "Member removed." : "Member not found (already removed).");
+  });
+
+// strus cluster suggest
+clusterCmd
+  .command("suggest")
+  .description("Suggest cluster candidates for a lemma")
+  .requiredOption("--lemma <id>", "Lemma ID")
+  .option("--limit <n>", "Max suggestions", "10")
+  .action(async (opts: { lemma: string; limit: string }) => {
+    const qs = new URLSearchParams({ lemmaId: opts.lemma, limit: opts.limit });
+    const result = await apiGet<{
+      suggestions: Array<{
+        lemmaId: string;
+        lemma: string;
+        pos: string | null;
+        score: number;
+        reasons: string[];
+      }>;
+    }>(`/api/clusters/suggest?${qs}`);
+
+    if (result.suggestions.length === 0) {
+      console.log("No suggestions found.");
+      return;
+    }
+
+    // Get the target lemma name for the header
+    const firstSugg = result.suggestions[0];
+    console.log(`\nSuggestions (${result.suggestions.length}):\n`);
+
+    for (const [i, s] of result.suggestions.entries()) {
+      const posLabel = s.pos ? `[${s.pos}]` : "";
+      const scoreStr = s.score.toFixed(2);
+      const reasonStr = s.reasons.join("; ");
+      console.log(
+        `  ${String(i + 1).padStart(2)}. ${s.lemma.padEnd(20)} ${posLabel.padEnd(12)} score: ${scoreStr}  — ${reasonStr}`,
+      );
+    }
+    console.log();
+  });
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Phase 5: semantic cluster management + cluster-aware distractor sourcing for choice notes.

## New API
- `POST /api/clusters` — create cluster
- `GET /api/clusters` — list with member counts
- `GET /api/clusters/:id` — get with member list (lemma text + POS)
- `POST /api/clusters/:id/members` — add member (idempotent)
- `DELETE /api/clusters/:id/members/:lemmaId` — remove member
- `GET /api/clusters/suggest` — suggest cluster candidates for a lemma (POS + shared concept scoring)

## New CLI
- `strus cluster create/list/show/add-member/remove-member/suggest`

## Generation integration
- `generateChoice` now fetches cluster siblings for the note's concept and injects them as preferred distractors into the LLM prompt
- `choice-v1.txt`: new `{{#cluster_distractors}}` section
- Falls back to LLM-invented distractors when no cluster siblings exist

## Schema notes
- `semantic_clusters` has a `cluster_type` NOT NULL column (prefix_family | vom_group | aspect_pair | custom) — included in `clusters.create`
- `semantic_cluster_members` has a composite PK (clusterId, lemmaId), no separate id column — `addMember` returns `{clusterId, lemmaId}`