### PR TITLE
test(generation): validate, zodToGeminiSchema, and createCardsForNote coverage

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,7 @@
     "start": "bun run src/index.ts",
     "generate:spec": "bun run scripts/generate-spec.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --preload ./src/test-setup.ts",
     "lint": "echo 'lint: ok'"
   },
   "dependencies": {

--- a/packages/api/src/generation/generate.test.ts
+++ b/packages/api/src/generation/generate.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { eq } from "drizzle-orm";
+import { createDb } from "@strus/db";
+import { notes, cards, clozeGaps } from "@strus/db";
+import { createCardsForNote } from "./generate.js";
+
+// ---------------------------------------------------------------------------
+// In-memory DB setup
+// ---------------------------------------------------------------------------
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../db/migrations");
+
+function createTestDb() {
+  const db = createDb(":memory:");
+  migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-01-15T12:00:00.000Z");
+
+function insertClozeNote(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(notes).values({
+    id,
+    kind: "cloze",
+    lemmaId: null,
+    front: null,
+    back: null,
+    sentenceId: null,
+    conceptId: null,
+    clusterId: null,
+    explanation: null,
+    status: "approved",
+    generationMeta: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).run();
+}
+
+function insertChoiceNote(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(notes).values({
+    id,
+    kind: "choice",
+    lemmaId: null,
+    front: "Jak powiedzieć 'house' po polsku?",
+    back: null,
+    sentenceId: null,
+    conceptId: null,
+    clusterId: null,
+    explanation: null,
+    status: "approved",
+    generationMeta: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).run();
+}
+
+function insertGap(
+  db: ReturnType<typeof createTestDb>,
+  noteId: string,
+  gapIndex: number,
+): string {
+  const gapId = randomUUID();
+  db.insert(clozeGaps).values({
+    id: gapId,
+    noteId,
+    gapIndex,
+    correctAnswers: JSON.stringify(["idzie"]),
+    hint: null,
+    conceptId: null,
+    difficulty: 2,
+    explanation: "Verb conjugation for 3rd person singular",
+    createdAt: NOW,
+  }).run();
+  return gapId;
+}
+
+// ---------------------------------------------------------------------------
+// createCardsForNote — cloze
+// ---------------------------------------------------------------------------
+
+describe("createCardsForNote — cloze notes", () => {
+  test("creates one cloze_fill card per gap", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertClozeNote(db, noteId);
+
+    const gapId1 = insertGap(db, noteId, 1);
+    const gapId2 = insertGap(db, noteId, 2);
+
+    const count = await createCardsForNote(db, { id: noteId, kind: "cloze" }, [
+      { id: gapId1 },
+      { id: gapId2 },
+    ]);
+
+    expect(count).toBe(2);
+
+    const created = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(created).toHaveLength(2);
+    expect(created.every((c) => c.kind === "cloze_fill")).toBe(true);
+  });
+
+  test("each card references its gap via gapId", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertClozeNote(db, noteId);
+
+    const gapId = insertGap(db, noteId, 1);
+
+    await createCardsForNote(db, { id: noteId, kind: "cloze" }, [{ id: gapId }]);
+
+    const created = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(created).toHaveLength(1);
+    expect(created[0]?.gapId).toBe(gapId);
+  });
+
+  test("fetches gaps from DB when not provided explicitly", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertClozeNote(db, noteId);
+
+    // Insert gaps directly, don't pass them to createCardsForNote
+    insertGap(db, noteId, 1);
+    insertGap(db, noteId, 2);
+
+    const count = await createCardsForNote(db, { id: noteId, kind: "cloze" });
+
+    expect(count).toBe(2);
+    const created = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(created).toHaveLength(2);
+  });
+
+  test("is idempotent — second call returns 0, card count stays the same", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertClozeNote(db, noteId);
+
+    const gapId1 = insertGap(db, noteId, 1);
+    const gapId2 = insertGap(db, noteId, 2);
+    const gaps = [{ id: gapId1 }, { id: gapId2 }];
+
+    await createCardsForNote(db, { id: noteId, kind: "cloze" }, gaps);
+    const second = await createCardsForNote(db, { id: noteId, kind: "cloze" }, gaps);
+
+    expect(second).toBe(0);
+
+    // Still exactly 2 cards — no duplicates
+    const all = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(all).toHaveLength(2);
+  });
+
+  test("creates cards in state=New with correct defaults", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertClozeNote(db, noteId);
+
+    const gapId = insertGap(db, noteId, 1);
+    await createCardsForNote(db, { id: noteId, kind: "cloze" }, [{ id: gapId }]);
+
+    const [card] = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(card).toBeDefined();
+    expect(card!.state).toBe(0); // CardState.New
+    expect(card!.reps).toBe(0);
+    expect(card!.lapses).toBe(0);
+    expect(card!.lastReview).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCardsForNote — choice notes
+// ---------------------------------------------------------------------------
+
+describe("createCardsForNote — choice notes", () => {
+  test("creates exactly one multiple_choice card", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertChoiceNote(db, noteId);
+
+    const count = await createCardsForNote(db, { id: noteId, kind: "choice" });
+
+    expect(count).toBe(1);
+
+    const created = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(created).toHaveLength(1);
+    expect(created[0]?.kind).toBe("multiple_choice");
+  });
+
+  test("is idempotent — second call for choice note returns 0", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+    insertChoiceNote(db, noteId);
+
+    await createCardsForNote(db, { id: noteId, kind: "choice" });
+    const second = await createCardsForNote(db, { id: noteId, kind: "choice" });
+
+    expect(second).toBe(0);
+    const all = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(all).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCardsForNote — other note kinds
+// ---------------------------------------------------------------------------
+
+describe("createCardsForNote — error and classifier notes", () => {
+  test("creates one error_correction card for 'error' kind", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+
+    db.insert(notes).values({
+      id: noteId,
+      kind: "error",
+      lemmaId: null,
+      front: "Ja jesteś student.",
+      back: "Ja jestem studentem.",
+      sentenceId: null,
+      conceptId: null,
+      clusterId: null,
+      explanation: null,
+      status: "approved",
+      generationMeta: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    }).run();
+
+    const count = await createCardsForNote(db, { id: noteId, kind: "error" });
+    expect(count).toBe(1);
+
+    const [card] = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(card?.kind).toBe("error_correction");
+  });
+
+  test("creates one classify card for 'classifier' kind", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+
+    db.insert(notes).values({
+      id: noteId,
+      kind: "classifier",
+      lemmaId: null,
+      front: null,
+      back: null,
+      sentenceId: null,
+      conceptId: null,
+      clusterId: null,
+      explanation: null,
+      status: "approved",
+      generationMeta: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    }).run();
+
+    const count = await createCardsForNote(db, { id: noteId, kind: "classifier" });
+    expect(count).toBe(1);
+
+    const [card] = db.select().from(cards).where(eq(cards.noteId, noteId)).all();
+    expect(card?.kind).toBe("classify");
+  });
+
+  test("returns 0 for unknown note kinds (no cards created)", async () => {
+    const db = createTestDb();
+    const noteId = randomUUID();
+
+    db.insert(notes).values({
+      id: noteId,
+      kind: "basic",
+      lemmaId: null,
+      front: "dom",
+      back: "house",
+      sentenceId: null,
+      conceptId: null,
+      clusterId: null,
+      explanation: null,
+      status: "approved",
+      generationMeta: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    }).run();
+
+    // 'basic' kind is not handled by createCardsForNote
+    const count = await createCardsForNote(db, { id: noteId, kind: "basic" });
+    expect(count).toBe(0);
+  });
+});

--- a/packages/api/src/generation/provider.test.ts
+++ b/packages/api/src/generation/provider.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+import { Type } from "@google/genai";
+import { zodToGeminiSchema } from "./provider.js";
+
+// ---------------------------------------------------------------------------
+// zodToGeminiSchema — Zod → Gemini SchemaType converter
+// ---------------------------------------------------------------------------
+
+describe("zodToGeminiSchema — leaf types", () => {
+  test("converts z.string()", () => {
+    expect(zodToGeminiSchema(z.string())).toEqual({ type: Type.STRING });
+  });
+
+  test("converts z.number()", () => {
+    expect(zodToGeminiSchema(z.number())).toEqual({ type: Type.NUMBER });
+  });
+
+  test("converts z.boolean()", () => {
+    expect(zodToGeminiSchema(z.boolean())).toEqual({ type: Type.BOOLEAN });
+  });
+});
+
+describe("zodToGeminiSchema — z.object", () => {
+  test("converts a flat object with required fields", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const result = zodToGeminiSchema(schema);
+    expect(result.type).toBe(Type.OBJECT);
+    expect(result.properties?.name).toEqual({ type: Type.STRING });
+    expect(result.properties?.age).toEqual({ type: Type.NUMBER });
+    expect(result.required).toContain("name");
+    expect(result.required).toContain("age");
+  });
+
+  test("optional fields are excluded from required[]", () => {
+    const schema = z.object({
+      name: z.string(),
+      nickname: z.string().optional(),
+    });
+    const result = zodToGeminiSchema(schema);
+    expect(result.required).toContain("name");
+    expect(result.required).not.toContain("nickname");
+  });
+
+  test("nullable fields are excluded from required[]", () => {
+    const schema = z.object({
+      required_field: z.string(),
+      nullable_field: z.string().nullable(),
+    });
+    const result = zodToGeminiSchema(schema);
+    expect(result.required).toContain("required_field");
+    expect(result.required).not.toContain("nullable_field");
+  });
+
+  test("empty object has no required array (or empty required)", () => {
+    const result = zodToGeminiSchema(z.object({}));
+    expect(result.type).toBe(Type.OBJECT);
+    // required should either be absent or empty
+    if (result.required !== undefined) {
+      expect(result.required).toHaveLength(0);
+    }
+  });
+});
+
+describe("zodToGeminiSchema — z.array", () => {
+  test("converts z.array of strings", () => {
+    const result = zodToGeminiSchema(z.array(z.string()));
+    expect(result.type).toBe(Type.ARRAY);
+    expect(result.items).toEqual({ type: Type.STRING });
+  });
+
+  test("converts z.array of numbers", () => {
+    const result = zodToGeminiSchema(z.array(z.number()));
+    expect(result.type).toBe(Type.ARRAY);
+    expect(result.items).toEqual({ type: Type.NUMBER });
+  });
+});
+
+describe("zodToGeminiSchema — unwrappers", () => {
+  test("unwraps z.optional correctly", () => {
+    const result = zodToGeminiSchema(z.string().optional());
+    expect(result.type).toBe(Type.STRING);
+  });
+
+  test("unwraps z.nullable correctly", () => {
+    const result = zodToGeminiSchema(z.string().nullable());
+    expect(result.type).toBe(Type.STRING);
+  });
+});
+
+describe("zodToGeminiSchema — enums", () => {
+  test("converts z.enum to STRING with enum values", () => {
+    const result = zodToGeminiSchema(z.enum(["a", "b", "c"]));
+    expect(result.type).toBe(Type.STRING);
+    expect(result.enum).toEqual(["a", "b", "c"]);
+  });
+
+  test("converts z.literal string to STRING with enum", () => {
+    const result = zodToGeminiSchema(z.literal("foo"));
+    expect(result.type).toBe(Type.STRING);
+    expect(result.enum).toEqual(["foo"]);
+  });
+});
+
+describe("zodToGeminiSchema — recursion regression", () => {
+  /**
+   * This is the critical regression test. Before the fix, nested z.object
+   * inside z.array was not recursed into — the raw Zod instance leaked into
+   * the output. Gemini's API rejects non-plain-object schemas silently or
+   * with cryptic errors.
+   */
+  test("recurses into nested z.object inside z.array (the regression case)", () => {
+    const schema = z.object({
+      gaps: z.array(
+        z.object({
+          gap_index: z.number(),
+          correct_answers: z.array(z.string()),
+          hint: z.string().optional(),
+        }),
+      ),
+    });
+
+    const result = zodToGeminiSchema(schema);
+
+    // gaps must be an ARRAY, not a raw Zod object
+    const gaps = result.properties?.gaps;
+    expect(gaps?.type).toBe(Type.ARRAY);
+
+    // items must be an OBJECT with properties, not a Zod instance
+    const items = gaps?.items;
+    expect(items?.type).toBe(Type.OBJECT);
+    expect(items?.properties?.gap_index).toEqual({ type: Type.NUMBER });
+    const correctAnswers = items?.properties?.correct_answers;
+    expect(correctAnswers?.type).toBe(Type.ARRAY);
+    expect(correctAnswers?.items).toEqual({ type: Type.STRING });
+
+    // No Zod class instances anywhere in the serialized output
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("ZodString");
+    expect(json).not.toContain("ZodObject");
+    expect(json).not.toContain("ZodArray");
+    expect(json).not.toContain("ZodNumber");
+    expect(json).not.toContain("ZodOptional");
+  });
+
+  test("converts the full ClozeNoteSchema without Zod leakage", () => {
+    // Mirrors the actual schema used in production
+    const ClozeNoteSchema = z.object({
+      sentence_text: z.string(),
+      translation: z.string().nullable(),
+      gaps: z.array(
+        z.object({
+          gap_index: z.number().int().min(1),
+          correct_answers: z.array(z.string().min(1)).min(1),
+          hint: z.string().nullable(),
+          explanation: z.string(),
+          why_not: z.string().nullable(),
+        }),
+      ).min(1),
+    });
+
+    const result = zodToGeminiSchema(ClozeNoteSchema);
+    const json = JSON.stringify(result);
+
+    // No Zod instances leaked
+    expect(json).not.toMatch(/Zod[A-Z]/);
+
+    // Top-level structure is correct
+    expect(result.type).toBe(Type.OBJECT);
+    expect(result.properties?.sentence_text).toEqual({ type: Type.STRING });
+
+    // gaps is an array of objects
+    const gapsSchema = result.properties?.gaps;
+    expect(gapsSchema?.type).toBe(Type.ARRAY);
+    const gapItem = gapsSchema?.items;
+    expect(gapItem?.type).toBe(Type.OBJECT);
+    const gapCorrectAnswers = gapItem?.properties?.correct_answers;
+    expect(gapCorrectAnswers?.type).toBe(Type.ARRAY);
+    expect(gapCorrectAnswers?.items).toEqual({ type: Type.STRING });
+  });
+});
+
+describe("zodToGeminiSchema — error cases", () => {
+  test("throws on unsupported type (z.date)", () => {
+    expect(() => zodToGeminiSchema(z.date())).toThrow();
+  });
+
+  test("throws on unsupported type (z.bigint)", () => {
+    expect(() => zodToGeminiSchema(z.bigint())).toThrow();
+  });
+});

--- a/packages/api/src/generation/provider.ts
+++ b/packages/api/src/generation/provider.ts
@@ -25,7 +25,7 @@ type GeminiSchema = {
   enum?: string[];
 };
 
-function zodToGeminiSchema(schema: z.ZodTypeAny): GeminiSchema {
+export function zodToGeminiSchema(schema: z.ZodTypeAny): GeminiSchema {
   if (schema instanceof z.ZodObject) {
     const props: Record<string, GeminiSchema> = {};
     const required: string[] = [];

--- a/packages/api/src/generation/validate.test.ts
+++ b/packages/api/src/generation/validate.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect } from "bun:test";
+import { validateSentenceLength, validateGapMarkers } from "./validate.js";
+
+// ---------------------------------------------------------------------------
+// validateSentenceLength
+// ---------------------------------------------------------------------------
+
+describe("validateSentenceLength", () => {
+  test("passes for a normal sentence with gap marker", () => {
+    const result = validateSentenceLength({
+      sentence_text: "Mój brat {{1}} na uniwersytecie w Warszawie.",
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("fails for sentence under 5 words", () => {
+    const result = validateSentenceLength({
+      sentence_text: "Idę {{1}}.",
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("Too short");
+  });
+
+  test("fails for sentence over 40 words", () => {
+    const long = Array(42).fill("słowo").join(" ") + " {{1}}";
+    const result = validateSentenceLength({
+      sentence_text: long,
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("Too long");
+  });
+
+  test("passes for exactly 5 words", () => {
+    // "To jest bardzo {{1}} zdanie." = 5 tokens
+    const result = validateSentenceLength({
+      sentence_text: "To jest bardzo {{1}} zdanie.",
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("passes for exactly 40 words", () => {
+    const exactly40 = Array(39).fill("słowo").join(" ") + " {{1}}";
+    const result = validateSentenceLength({
+      sentence_text: exactly40,
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("counts words by splitting on whitespace, ignoring empty chunks", () => {
+    // Leading/trailing spaces shouldn't create phantom words
+    const result = validateSentenceLength({
+      sentence_text: "  Ona {{1}} do domu.  ",
+      translation: null,
+      gaps: [],
+    });
+    // "Ona", "{{1}}", "do", "domu." = 4 words → too short
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("Too short");
+  });
+
+  test("layer is 'length'", () => {
+    const result = validateSentenceLength({
+      sentence_text: "Mój brat {{1}} na uniwersytecie w Warszawie.",
+      translation: null,
+      gaps: [],
+    });
+    expect(result.layer).toBe("length");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateGapMarkers
+// ---------------------------------------------------------------------------
+
+describe("validateGapMarkers", () => {
+  test("passes when all gap indices are present in sentence text", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Ona {{1}} do {{2}}.",
+      translation: null,
+      gaps: [
+        { gap_index: 1, correct_answers: ["idzie"], hint: null, explanation: "", why_not: null },
+        { gap_index: 2, correct_answers: ["domu"], hint: null, explanation: "", why_not: null },
+      ],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("fails when a declared gap index is missing from text", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Ona {{1}} do domu.",
+      translation: null,
+      gaps: [
+        { gap_index: 1, correct_answers: ["idzie"], hint: null, explanation: "", why_not: null },
+        { gap_index: 2, correct_answers: ["domu"], hint: null, explanation: "", why_not: null },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    // Should mention the missing index
+    expect(result.reason).toContain("2");
+  });
+
+  test("passes with no gaps declared and no markers in text", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Ona idzie do domu.",
+      translation: null,
+      gaps: [],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("fails when multiple gap indices are missing", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Słowo.",
+      translation: null,
+      gaps: [
+        { gap_index: 1, correct_answers: ["a"], hint: null, explanation: "", why_not: null },
+        { gap_index: 2, correct_answers: ["b"], hint: null, explanation: "", why_not: null },
+        { gap_index: 3, correct_answers: ["c"], hint: null, explanation: "", why_not: null },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("1");
+    expect(result.reason).toContain("2");
+    expect(result.reason).toContain("3");
+  });
+
+  test("passes with a single gap present", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Piszę {{1}} list.",
+      translation: null,
+      gaps: [
+        { gap_index: 1, correct_answers: ["długi"], hint: null, explanation: "", why_not: null },
+      ],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("layer is 'gap_markers'", () => {
+    const result = validateGapMarkers({
+      sentence_text: "Ona {{1}} do domu.",
+      translation: null,
+      gaps: [{ gap_index: 1, correct_answers: ["idzie"], hint: null, explanation: "", why_not: null }],
+    });
+    expect(result.layer).toBe("gap_markers");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NOTE: validateMorphology is intentionally not tested here.
+// It requires @rzyns/morfeusz-ts (native TypeScript port of Morfeusz2 with
+// dictionary files at /usr/share/morfeusz2/dictionaries). Mocking the
+// `analyse` export from @strus/morph would require a bun mock() call that
+// intercepts the module — doable but deferred until the CI environment has
+// the native dict files confirmed present.
+// ---------------------------------------------------------------------------

--- a/packages/api/src/test-setup.ts
+++ b/packages/api/src/test-setup.ts
@@ -1,0 +1,4 @@
+// Test environment setup — preloaded before any test file is evaluated.
+// Sets required environment variables so module-level DB singletons
+// don't throw during import in test contexts.
+process.env.STRUS_DB_PATH = process.env.STRUS_DB_PATH ?? ":memory:";


### PR DESCRIPTION
Adds test coverage for the highest-priority pure functions and critical invariants from Phases 3–5.

## What's tested
- `validateSentenceLength`: too short, too long, exact boundary, whitespace handling, layer name
- `validateGapMarkers`: all indices present, single missing index, multiple missing, no gaps, layer name
- `zodToGeminiSchema`: leaf types (string/number/boolean), flat objects with required/optional/nullable, arrays, enum, literal, unwrappers, and nested array-of-object recursion (the regression from code-review round 1), unsupported type throws — 17 tests
- `createCardsForNote`: correct card kind per note kind (cloze→cloze_fill, choice→multiple_choice, error→error_correction, classifier→classify), gaps fetched from DB when not passed, gapId linked on card, FSRS defaults on new cards, idempotency (second call returns 0 and card count unchanged) — 10 tests

## Implementation notes
- Exported `zodToGeminiSchema` from `provider.ts` (was internal, no behavior change)
- Added `src/test-setup.ts` preload that sets `STRUS_DB_PATH=:memory:` so DB singleton doesn't throw at import time in tests
- Updated `packages/api` test script to `bun test --preload ./src/test-setup.ts`
- `generate.test.ts` uses `createDb(':memory:')` + `migrate()` with the real migrations folder for DB tests

## What's not tested (and why)
- `validateMorphology`: requires `@rzyns/morfeusz-ts` native binding + dict files at `/usr/share/morfeusz2/dictionaries`; skipped pending CI native deps setup
- Cluster suggestion scoring: logic embedded in DB query; would require refactor to test purely
- API procedure integration: oRPC procedure wiring not tested here; deferred to follow-up PR