### PR TITLE
feat(ci): publish npm packages to GitHub Packages on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,36 @@ jobs:
         run: bun install --frozen-lockfile
 
       # -----------------------------------------------------------------------
+      # Sync package versions from git tag & publish to GitHub Packages
+      # -----------------------------------------------------------------------
+      - name: Set package versions from tag
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"   # strip 'v' prefix → "1.2.3"
+          echo "Publishing version: $VERSION"
+          find packages -name "package.json" -not -path "*/node_modules/*" \
+            -exec sh -c '
+              tmp=$(mktemp)
+              jq --arg v "$1" ".version = \$v" "$2" > "$tmp" && mv "$tmp" "$2"
+            ' _ "$VERSION" {} \;
+
+      - name: Configure npm for GitHub Packages
+        run: |
+          echo "@rzyns:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+
+      - name: Publish packages to GitHub Packages
+        run: |
+          for pkg in config core morph db api cli; do
+            echo "--- Publishing @rzyns/strus-$pkg ---"
+            cd packages/$pkg
+            bun publish --access public
+            cd ../..
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # -----------------------------------------------------------------------
       # Generate changelog (commits since last tag)
       # -----------------------------------------------------------------------
       - name: Generate changelog

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-api",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Elysia + oRPC HTTP server for strus",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-cli",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Commander.js CLI for strus",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-config",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Validated configuration for strus services",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-core",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Domain types and FSRS scheduling logic for strus",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-db",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Drizzle ORM schema, migrations, and query helpers for strus",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rzyns/strus-morph",
   "version": "2.0.0-beta.4",
-  "private": true,
   "description": "Thin wrapper around the Morfeusz2 Polish morphological analyser CLI",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Adds npm package publishing to the release workflow alongside the existing Docker/GHCR publishing.

## What changes

**Package configs:**
- Removes `"private": true` from 6 packages (`config`, `core`, `morph`, `db`, `api`, `cli`)
- `web` stays private — SolidJS app has no value as an npm package

**release.yml additions (3 new steps):**
1. **Version sync** — sets all `package.json` version fields from the git tag (e.g. `v1.2.3` → `1.2.3`)
2. **Registry config** — configures `~/.npmrc` for `@rzyns` scope → `https://npm.pkg.github.com`
3. **Publish** — `bun publish --access public` in dependency order

## Publish order
`config` → `core` → `morph` → `db` → `api` → `cli`

## After merge
Push a `v*` tag to trigger a release. Users can install the CLI with:
```bash
# ~/.bunfig.toml
[install.scopes]
"@rzyns" = { url = "https://npm.pkg.github.com/", token = "$GITHUB_TOKEN" }

# then:
bun install -g @rzyns/strus-cli
```