### PR TITLE
fix(ci): use BUN_AUTH_TOKEN and publishConfig for bun publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,21 +42,23 @@ jobs:
               jq --arg v "$1" ".version = \$v" "$2" > "$tmp" && mv "$tmp" "$2"
             ' _ "$VERSION" {} \;
 
-      - name: Configure npm for GitHub Packages
+      - name: Write bunfig for GitHub Packages auth
         run: |
-          echo "@rzyns:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+          cat >> ~/.bunfig.toml << 'EOF'
+          [install.scopes]
+          "@rzyns" = { url = "https://npm.pkg.github.com/", token = "$BUN_AUTH_TOKEN" }
+          EOF
 
       - name: Publish packages to GitHub Packages
+        env:
+          BUN_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for pkg in config core morph db api cli; do
             echo "--- Publishing @rzyns/strus-$pkg ---"
             cd packages/$pkg
-            bun publish --access public
+            bun publish
             cd ../..
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # -----------------------------------------------------------------------
       # Generate changelog (commits since last tag)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,5 +41,9 @@
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,5 +27,9 @@
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,5 +17,9 @@
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,5 +26,9 @@
     "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.9",
     "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -17,6 +17,10 @@
     "@types/bun": "^1.1.0",
     "typescript": "^5.7.0"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "dependencies": {
     "@rzyns/morfeusz-ts": "https://github.com/rzyns/morfeusz-ts/releases/download/v1.0.3/rzyns-morfeusz-ts-1.0.3.tgz"
   }


### PR DESCRIPTION
Fixes missing authentication error in the npm publish step.

## Problem
`bun publish` v1.3.9 does not read `~/.npmrc` for auth tokens.
The previous workflow wrote `_authToken` to `~/.npmrc` which npm reads
but bun ignores.

Error: `error: missing authentication (run `bunx npm login`)`
Run: https://github.com/rzyns/strus/actions/runs/22823177579/job/66199115497

## Fix
1. Add `publishConfig.registry` to each publishable `package.json` so bun knows the target registry per-package
2. Write `~/.bunfig.toml` with `BUN_AUTH_TOKEN`-referenced token for the `@rzyns` scope
3. Set `BUN_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the publish step
4. Remove the old `~/.npmrc` approach