### PR TITLE
fix(ci): use actions/setup-node + npm publish for GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,21 +42,20 @@ jobs:
               jq --arg v "$1" ".version = \$v" "$2" > "$tmp" && mv "$tmp" "$2"
             ' _ "$VERSION" {} \;
 
-      - name: Write bunfig for GitHub Packages auth
-        run: |
-          cat >> ~/.bunfig.toml << 'EOF'
-          [install.scopes]
-          "@rzyns" = { url = "https://npm.pkg.github.com/", token = "$BUN_AUTH_TOKEN" }
-          EOF
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@rzyns'
 
       - name: Publish packages to GitHub Packages
         env:
-          BUN_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for pkg in config core morph db api cli; do
             echo "--- Publishing @rzyns/strus-$pkg ---"
             cd packages/$pkg
-            bun publish
+            npm publish
             cd ../..
           done
 


### PR DESCRIPTION
Third attempt at fixing npm publish auth.

## Problem
`bun publish` v1.3.9 does not correctly authenticate against custom registries even with:
- `BUN_AUTH_TOKEN` env var set ✗
- `~/.bunfig.toml` with token ✗

Root cause: Bun's custom registry auth via `BUN_AUTH_TOKEN` applies to the default npmjs.org registry; custom registries need different wiring that varies by bun version.

## Fix
Switch to `npm publish` with `actions/setup-node`:
- `actions/setup-node@v4` with `registry-url` + `scope` automatically creates the correct `~/.npmrc` for GitHub Packages
- `NODE_AUTH_TOKEN` is the documented mechanism and works reliably
- `publishConfig` in each `package.json` (from PR #42) already points to the right registry and sets `access: public`
- npm is available on ubuntu-latest runners

Failed runs:
- https://github.com/rzyns/strus/actions/runs/22823177579 (npmrc approach)
- https://github.com/rzyns/strus/actions/runs/22823554613 (BUN_AUTH_TOKEN approach)