### PR TITLE
fix(ci): replace workspace:* with release version before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,15 @@ jobs:
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"   # strip 'v' prefix → "1.2.3"
           echo "Publishing version: $VERSION"
-          find packages -name "package.json" -not -path "*/node_modules/*" \
-            -exec sh -c '
-              tmp=$(mktemp)
-              jq --arg v "$1" ".version = \$v" "$2" > "$tmp" && mv "$tmp" "$2"
-            ' _ "$VERSION" {} \;
+          for pkg in config core morph db api cli web; do
+            PKG_JSON="packages/$pkg/package.json"
+            tmp=$(mktemp)
+            jq --arg v "$VERSION" '
+              .version = $v |
+              .dependencies = (.dependencies // {} | with_entries(if .value == "workspace:*" then .value = $v else . end)) |
+              .peerDependencies = (.peerDependencies // {} | with_entries(if .value == "workspace:*" then .value = $v else . end))
+            ' "$PKG_JSON" > "$tmp" && mv "$tmp" "$PKG_JSON"
+          done
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem
`npm publish` does not understand the `workspace:*` protocol and publishes it verbatim.
Consumers installing `@rzyns/strus-cli` see e.g. `"@rzyns/strus-api": "workspace:*"`
and fail to resolve it:

```
error: Workspace dependency "@rzyns/strus-api" not found
error: @rzyns/strus-api@workspace:* failed to resolve
```

## Fix
Extend the existing version sync step (which already rewrites `.version`) to also replace
`workspace:*` in `dependencies` and `peerDependencies` with the actual release version
before `npm publish` runs.

Also switched from `find -exec sh -c` to a clean `for` loop to avoid shell quoting
hell inside nested exec contexts.

Published tarballs will now contain concrete version numbers (e.g. `"2.0.0-beta.8"`)
that npm/bun can resolve from GitHub Packages.