### PR TITLE
feat(web): contextual note detail rendering + inline triage

### DIFF
--- a/packages/web/src/routes/notes/[id].tsx
+++ b/packages/web/src/routes/notes/[id].tsx
@@ -544,6 +544,8 @@ export default function NoteDetail() {
     } catch (err) {
       setTriageError(String(err))
       setTriagePhase('idle')
+      setTriagePendingAction(null)
+      setTriageReason('')
     }
   }
 


### PR DESCRIPTION
Extends /notes/:id to render cloze, choice, error, and classifier notes with their sentences, gaps, options, and explanations. Adds status badge and inline Approve/Flag/Reject triage for contextual kinds. Extends Preview tab to handle contextual card kinds. Depends on #45 (API extensions, merged) and #46 (review queue, merged).