### PR TITLE
fix(api): coerce limit/offset to number in clustersList input schema

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -3162,7 +3162,7 @@ const clustersSuggest = os
   })
   .input(z.object({
     lemmaId: zId,
-    limit: z.number().int().min(1).max(50).default(10),
+    limit: z.coerce.number().int().min(1).max(50).default(10),
   }))
   .output(z.object({
     suggestions: z.array(z.object({
@@ -3386,8 +3386,8 @@ const notesListDrafts = os
       status: z.enum(["draft", "flagged", "approved", "rejected"]).optional().describe("Filter by note status; omit for all statuses"),
       kind: z.enum(["cloze", "choice", "error", "classifier"]).optional().describe("Filter by note kind"),
       batchId: z.string().optional().describe("Filter by generation batch ID (matches generation_meta.batchId)"),
-      limit: z.number().int().min(1).max(100).default(20).describe("Maximum notes to return"),
-      offset: z.number().int().min(0).default(0).describe("Pagination offset"),
+      limit: z.coerce.number().int().min(1).max(100).default(20).describe("Maximum notes to return"),
+      offset: z.coerce.number().int().min(0).default(0).describe("Pagination offset"),
     }),
   )
   .output(


### PR DESCRIPTION
## Problem

`strus cluster list` was failing with a 400 BAD_REQUEST:

```
Input validation failed: limit: Expected number, received string, offset: Expected number, received string
```

## Root cause

Query parameters always arrive as strings over HTTP. The `clustersList` route input schema used `z.number()` for `limit` and `offset`, which rejects strings. All other list endpoints in the router already use `z.coerce.number()`.

## Fix

Two-character change: `z.number()` → `z.coerce.number()` for both fields in the `clustersList` input schema.

## Testing

- `bun run typecheck` — all packages clean
- `bun test` — 226/227 pass (1 pre-existing failure: `generate.test.ts` requires `STRUS_DB_PATH` env, unrelated to this change)