### PR TITLE
feat: add POST /api/lists/{listId}/notes endpoint

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -592,6 +592,57 @@ const listsAddLemma = os
 
 // ---------------------------------------------------------------------------
 // Lemmas procedures
+const listsAddNote = os
+  .route({
+    method: "POST",
+    path: "/lists/{listId}/notes",
+    tags: ["Lists"],
+    summary: "Add a note to a vocabulary list",
+    description:
+      "Associates an existing note directly with a vocabulary list. " +
+      "Idempotent — calling twice with the same IDs returns success both times.",
+  })
+  .input(z.object({
+    listId: zId.describe("ID of the vocabulary list"),
+    noteId: zId.describe("ID of the note to add"),
+  }))
+  .output(SuccessOutput)
+  .handler(async ({ input }) => {
+    // Verify the list exists
+    const [list] = await db
+      .select({ id: vocabLists.id })
+      .from(vocabLists)
+      .where(eq(vocabLists.id, input.listId))
+      .limit(1);
+
+    if (!list) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Vocabulary list not found: ${input.listId}`,
+      });
+    }
+
+    // Verify the note exists
+    const [note] = await db
+      .select({ id: notes.id })
+      .from(notes)
+      .where(eq(notes.id, input.noteId))
+      .limit(1);
+
+    if (!note) {
+      throw new ORPCError("NOT_FOUND", {
+        message: `Note not found: ${input.noteId}`,
+      });
+    }
+
+    // Insert idempotently (primaryKey constraint on (listId, noteId))
+    await db
+      .insert(vocabListNotes)
+      .values({ listId: input.listId, noteId: input.noteId })
+      .onConflictDoNothing();
+
+    return { success: true as const };
+  });
+
 // ---------------------------------------------------------------------------
 
 const lemmasList = os
@@ -3635,6 +3686,7 @@ export const router = {
     get: listsGet,
     delete: listsDelete,
     addLemma: listsAddLemma,
+    addNote: listsAddNote,
   },
   grammarConcepts: {
     list: grammarConceptsList,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -163,6 +163,19 @@ listCmd
     console.log(`Added lemma ${lemmaId} to list ${listId}`);
   });
 
+listCmd
+  .command("add-note")
+  .description("Add a note directly to a vocabulary list")
+  .requiredOption("--list <listId>", "ID of the vocabulary list")
+  .requiredOption("--note <noteId>", "ID of the note to add")
+  .action(async (opts: { list: string; note: string }) => {
+    await apiPost<{ success: true }>(
+      `/api/lists/${encodeURIComponent(opts.list)}/notes`,
+      { listId: opts.list, noteId: opts.note },
+    );
+    console.log(`Added note ${opts.note} to list ${opts.list}`);
+  });
+
 // ---------------------------------------------------------------------------
 // strus lemma
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `POST /api/lists/{listId}/notes` — a direct note-to-list association endpoint.

## Why

The existing `POST /api/lists/{listId}/lemmas` endpoint associates a lemma's morph note with a list (via the lemma). This new endpoint skips the lemma lookup and directly links any note by ID. Needed for cases where you have a `noteId` in hand (e.g. basic notes, gloss notes) and want to add it to a list without going through a lemma.

## Changes

**`packages/api/src/router.ts`**
- New `listsAddNote` procedure at `POST /lists/{listId}/notes`
- Accepts `{ listId: UUID, noteId: UUID }`
- Verifies list exists → 404 if not
- Verifies note exists → 404 if not
- Idempotent insert via `onConflictDoNothing` (the `vocab_list_notes` table has a primary key on `(listId, noteId)`)
- Returns `{ success: true }`
- Wired into router as `lists.addNote`

**`packages/cli/src/index.ts`**
- New `strus list add-note --list <listId> --note <noteId>` command

## Verification

Tested manually against live API:
- ✅ `{ success: true }` on first call
- ✅ `{ success: true }` on second call (idempotent)
- ✅ 404 for non-existent listId
- ✅ 404 for non-existent noteId
- ✅ All 236 existing tests pass

## Notes

No schema changes — purely additive. Uses the `vocabListNotes` table that already exists.