### PR TITLE
chore: add lefthook with git-bug bridge push pre-push hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,17 +7,18 @@
       "devDependencies": {
         "@commitlint/cli": "^20.4.3",
         "@commitlint/config-conventional": "^20.4.3",
-        "@types/bun": "^1.1.0",
+        "@types/bun": "^1.3.10",
         "bumpp": "^10.4.1",
         "concurrently": "^9.2.1",
         "conventional-changelog-cli": "^5.0.0",
-        "conventional-changelog-conventionalcommits": "^9.2.0",
-        "typescript": "^5.7.0",
+        "conventional-changelog-conventionalcommits": "^9.3.0",
+        "lefthook": "^2.1.3",
+        "typescript": "^5.9.3",
       },
     },
     "packages/api": {
       "name": "@rzyns/strus-api",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "@elysiajs/opentelemetry": "^1.4.10",
         "@elysiajs/static": "^1.4.7",
@@ -46,7 +47,7 @@
     },
     "packages/cli": {
       "name": "@rzyns/strus-cli",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "bin": {
         "strus": "./src/index.ts",
       },
@@ -64,7 +65,7 @@
     },
     "packages/config": {
       "name": "@rzyns/strus-config",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "zod": "^3.23.0",
       },
@@ -75,7 +76,7 @@
     },
     "packages/core": {
       "name": "@rzyns/strus-core",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "@rzyns/strus-morph": "workspace:*",
         "ts-fsrs": "^5.2.3",
@@ -87,7 +88,7 @@
     },
     "packages/db": {
       "name": "@rzyns/strus-db",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "@rzyns/strus-config": "workspace:*",
         "@rzyns/strus-core": "workspace:*",
@@ -102,7 +103,7 @@
     },
     "packages/morph": {
       "name": "@rzyns/strus-morph",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "@rzyns/morfeusz-ts": "https://github.com/rzyns/morfeusz-ts/releases/download/v1.0.3/rzyns-morfeusz-ts-1.0.3.tgz",
       },
@@ -113,7 +114,7 @@
     },
     "packages/web": {
       "name": "@rzyns/strus-web",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.20",
       "dependencies": {
         "@ark-ui/solid": "^5.34.0",
         "@opentelemetry/api": "^1.9.0",
@@ -1074,6 +1075,28 @@
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lefthook": ["lefthook@2.1.3", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.3", "lefthook-darwin-x64": "2.1.3", "lefthook-freebsd-arm64": "2.1.3", "lefthook-freebsd-x64": "2.1.3", "lefthook-linux-arm64": "2.1.3", "lefthook-linux-x64": "2.1.3", "lefthook-openbsd-arm64": "2.1.3", "lefthook-openbsd-x64": "2.1.3", "lefthook-windows-arm64": "2.1.3", "lefthook-windows-x64": "2.1.3" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-2W8PP/EGCvyS/x+Xza0Lgvn/EM3FKnr6m6xkfzpl6RKHl8TwPvs9iYZFQL99CnWTTvO+1mtQvIxGE/bD05038Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VMSQK5ZUh66mKrEpHt5U81BxOg5xAXLoLZIK6e++4uc28tj8zGBqV9+tZqSRElXXzlnHbfdDVCMaKlTuqUy0Rg=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-4QhepF4cf+fa7sDow29IEuCfm/6LuV+oVyQGpnr5it1DEZIEEoa6vdH/x4tutYhAg/HH7I2jHq6FGz96HRiJEQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-kysx/9pjifOgcTZOj1bR0i74FAbMv3BDfrpZDKniBOo4Dp0hXhyOtUmRn4nWKL0bN+cqc4ZePAq4Qdm4fxWafA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TLuPHQNg6iihShchrh5DrHvoCZO8FajZBMAEwLIKWlm6bkCcXbYNxy4dBaVK8lzHtS/Kv1bnH0D3BcK65iZFVQ=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-e5x4pq1aZAXc0C642V4HaUoKtcHVmGW1HBIDNfWUhtsThBKjhZBXPspecaAHIRA/8VtsXS3RnJ4VhQpgfrCbww=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-yeVAiV5hoE6Qq8dQDB4XC14x4N9mhn+FetxzqDu5LVci0/sOPqyPq2b0YUtNwJ1ZUKawTz4I/oqnUsHkQrGH0w=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-8QVvRxIosV6NL2XrbifOPGVhMFE43h02BUNEHYhZhyad7BredfAakg9dA9J/NO0I3eMdvCYU50ubFyDGIqUJog=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-YTS9qeW9PzzKg9Rk55mQprLIl1OdAIIjeOH8DF+MPWoAPkRqeUyq8Q2Bdlf3+Swy+kJOjoiU1pKvpjjc8upv9Q=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-Nlp80pWyF67GmxgM5NQmL7JTTccbJAvCNtS5QwHmKq3pJ9Xi0UegP9pGME520n06Rhp+gX7H4boXhm2D5hAghg=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-KByBhvqgUNhjO/03Mr0y66D9B1ZnII7AB0x17cumwHMOYoDaPJh/AlgmEduqUpatqli3lnFzWD0DUkAY6pq/SA=="],
 
     "lightningcss": ["lightningcss@1.25.1", "", { "dependencies": { "detect-libc": "1.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.25.1", "lightningcss-darwin-x64": "1.25.1", "lightningcss-freebsd-x64": "1.25.1", "lightningcss-linux-arm-gnueabihf": "1.25.1", "lightningcss-linux-arm64-gnu": "1.25.1", "lightningcss-linux-arm64-musl": "1.25.1", "lightningcss-linux-x64-gnu": "1.25.1", "lightningcss-linux-x64-musl": "1.25.1", "lightningcss-win32-x64-msvc": "1.25.1" } }, "sha512-V0RMVZzK1+rCHpymRv4URK2lNhIRyO8g7U7zOFwVAhJuat74HtkjIQpQRKNCwFEYkRGpafOpmXXLoaoBcyVtBg=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-push:
+  commands:
+    sync-bugs:
+      run: git bug bridge push
+      fail_text: |
+        git-bug bridge push failed.
+        Bug state is safe locally in refs/bugs/ — fix auth/network then run:
+          git bug bridge push
+          git push

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Polish morphological spaced repetition system",
   "scripts": {
+    "prepare": "lefthook install",
     "build": "bun run --filter '*' build",
     "dev": "concurrently --names api,web --prefix-colors cyan,magenta \"bun run --filter @rzyns/strus-api dev\" \"bun run --filter @rzyns/strus-web dev\"",
     "test": "bun run --filter '*' test",
@@ -21,6 +22,7 @@
     "concurrently": "^9.2.1",
     "conventional-changelog-cli": "^5.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.0",
+    "lefthook": "^2.1.3",
     "typescript": "^5.9.3"
   },
   "engines": {


### PR DESCRIPTION
## What

- Installs `lefthook@2.1.3` as a devDependency
- Adds `lefthook.yml` with a `pre-push` hook that runs `git bug bridge push` (hard-fail)
- Adds `prepare` script so `bun install` auto-installs hooks after a fresh clone

## Why

Part of improving multi-agent coordination reliability. git-bug is the canonical issue backlog for strus (issues live in `refs/bugs/` and sync to GitHub Issues via bridge). The pre-push hook ensures bug state is always pushed to GitHub when code is pushed — hard-failing so drift doesn't silently accumulate.

If the bridge push fails, bug state is safe locally in `refs/bugs/`; fix auth/network and retry.