### PR TITLE
feat(cli): add --list flag to generate command for auto-assigning notes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1133,20 +1133,25 @@ generateCmd
       console.log(JSON.stringify(result, null, 2));
 
       if (opts.list && result.batchId) {
-        // Fetch all notes from this batch
-        const notesResult = await apiGet<Array<{ id: string }>>(
-          `/api/notes?batchId=${encodeURIComponent(result.batchId)}&status=approved&limit=100`
-        );
-        const noteIds = notesResult.map((n) => n.id);
-        if (noteIds.length === 0) {
-          console.log("No approved notes to assign to list.");
-        } else {
-          let assigned = 0;
-          for (const noteId of noteIds) {
-            await apiPost<{ success: true }>(`/api/lists/${opts.list}/notes`, { listId: opts.list, noteId });
-            assigned++;
+        try {
+          // Fetch all approved notes from this batch via the correct drafts endpoint
+          const notesResult = await apiGet<{ notes: Array<{ id: string }>; total: number }>(
+            `/api/notes/drafts?batchId=${encodeURIComponent(result.batchId)}&status=approved&limit=100`
+          );
+          const noteIds = notesResult.notes.map((n) => n.id);
+          if (noteIds.length === 0) {
+            console.log("No approved notes to assign to list.");
+          } else {
+            let assigned = 0;
+            for (const noteId of noteIds) {
+              await apiPost<{ success: true }>(`/api/lists/${opts.list}/notes`, { listId: opts.list, noteId });
+              assigned++;
+            }
+            console.log(`Assigned ${assigned} note(s) to list ${opts.list}.`);
           }
-          console.log(`Assigned ${assigned} note(s) to list ${opts.list}.`);
+        } catch (err) {
+          console.error(`Warning: notes were generated but could not be assigned to list ${opts.list}:`, err instanceof Error ? err.message : err);
+          process.exit(1);
         }
       }
     },


### PR DESCRIPTION
## What

Adds a `--list <uuid>` option to the `strus generate` CLI command.

## Why

After batch generation, users previously had to manually assign notes to a vocab list. This flag makes it a single step.

## How

After the existing `/api/generation/generate` call completes and its result is printed, the new logic:

1. Fetches all approved notes from the batch via `GET /api/notes?batchId=...&status=approved&limit=100`
2. POSTs each note to `/api/lists/{listId}/notes` sequentially

Sequential loop (not parallel) — avoids race conditions at 5–20 notes scale.

No API-side changes. Uses existing `apiGet`/`apiPost` helpers.