### PR TITLE
fix(web): add conditional (cond) to tag label maps

### DIFF
--- a/packages/openclaw-plugin/src/tag-labels.ts
+++ b/packages/openclaw-plugin/src/tag-labels.ts
@@ -132,6 +132,13 @@ export function tagLabel(tag: string): string {
     return `imperative ${personLabel} ${num === "sg" ? "sg." : "pl."}`;
   }
 
+  // Conditional: cond:number:gender:aspect
+  if (pos === "cond" && parts.length >= 3) {
+    const num = NUMBER_MAP[parts[1]] ?? parts[1];
+    const gender = parts[2] ? formatGender(parts[2]) : "";
+    return `conditional ${num}${gender ? " " + gender : ""}${aspect}`;
+  }
+
   // Gerund / verbal noun: ger:number:case:gender:aspect...
   if (pos === "ger" && parts.length >= 3) {
     const num = NUMBER_MAP[parts[1]] ?? parts[1];

--- a/packages/web/src/utils/tag-label.ts
+++ b/packages/web/src/utils/tag-label.ts
@@ -14,6 +14,7 @@ const POS_PREFIX: Record<string, string> = {
   pant:   'anterior adverbial participle (converb)',
   imps:   'impersonal form',
   bedzie: 'future',
+  cond:   'conditional',
   winien: 'ought-to form',
 }
 


### PR DESCRIPTION
Adds `cond` → 'conditional' to both the web UI tag-label utility and the OpenClaw plugin tag-labels.

**Problem:** When a quiz is focused on tryb przypuszczający (conditional mood), cards with `cond:*` tags don't show 'conditional' in their prompt — making it impossible to know which form is expected.

**Fix:** 
- `packages/web/src/utils/tag-label.ts`: added `cond: 'conditional'` to POS_PREFIX
- `packages/openclaw-plugin/src/tag-labels.ts`: added full `cond` handler with number/gender/aspect formatting

One-line + one-block fix. No schema/API changes.