### PR TITLE
STR-19: add FSRS columns to knowledge components

### DIFF
--- a/packages/api/src/analytics-kc-mastery.test.ts
+++ b/packages/api/src/analytics-kc-mastery.test.ts
@@ -10,7 +10,13 @@ import { randomUUID } from "node:crypto";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import { call } from "@orpc/server";
 import { db } from "@rzyns/strus-db";
-import { knowledgeComponents, cardKnowledgeComponents, cards, notes } from "@rzyns/strus-db";
+import {
+  knowledgeComponents,
+  cardKnowledgeComponents,
+  cards,
+  notes,
+  createInitialKnowledgeComponentFsrsState,
+} from "@rzyns/strus-db";
 import { router } from "./router.js";
 
 // ---------------------------------------------------------------------------
@@ -35,6 +41,7 @@ function makeKC(opts: {
   labelPl?: string;
 }): string {
   const id = randomUUID();
+  const fsrs = createInitialKnowledgeComponentFsrsState();
   db.insert(knowledgeComponents).values({
     id,
     kind: opts.kind ?? "case",
@@ -42,6 +49,7 @@ function makeKC(opts: {
     labelPl: opts.labelPl ?? null,
     tagPattern: "*:gen:*",
     lemmaId: null,
+    ...fsrs,
     createdAt: NOW,
   }).run();
   return id;

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -24,6 +24,7 @@ import {
   semanticClusterMembers,
   knowledgeComponents,
   cardKnowledgeComponents,
+  createInitialKnowledgeComponentFsrsState,
   mapCardToKCs,
   seedKCs,
   backfillKCs,
@@ -351,6 +352,7 @@ async function linkCardToKCs(
 
     if (!lemmaKC) {
       const kcId = `kc-lemma-${lemmaId}`;
+      const fsrs = createInitialKnowledgeComponentFsrsState();
       db.insert(knowledgeComponents).values({
         id: kcId,
         kind: "lemma",
@@ -358,6 +360,7 @@ async function linkCardToKCs(
         labelPl: null,
         tagPattern: null,
         lemmaId,
+        ...fsrs,
         createdAt: new Date(),
       }).run();
       lemmaKC = { id: kcId };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "build": "tsc --project tsconfig.json",
     "dev": "bun run src/index.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --pass-with-no-tests",
     "lint": "echo 'lint: ok'"
   },
   "dependencies": {

--- a/packages/db/migrations/0014_steady_donald_blake.sql
+++ b/packages/db/migrations/0014_steady_donald_blake.sql
@@ -1,0 +1,62 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_knowledge_components` (
+	`id` text PRIMARY KEY NOT NULL,
+	`kind` text NOT NULL,
+	`label` text NOT NULL,
+	`label_pl` text,
+	`tag_pattern` text,
+	`lemma_id` text,
+	`state` integer DEFAULT 0 NOT NULL,
+	`due` integer NOT NULL,
+	`stability` real DEFAULT 0 NOT NULL,
+	`difficulty` real DEFAULT 0 NOT NULL,
+	`elapsed_days` integer DEFAULT 0 NOT NULL,
+	`scheduled_days` integer DEFAULT 0 NOT NULL,
+	`reps` integer DEFAULT 0 NOT NULL,
+	`lapses` integer DEFAULT 0 NOT NULL,
+	`last_review` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`lemma_id`) REFERENCES `lemmas`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_knowledge_components`(
+	`id`,
+	`kind`,
+	`label`,
+	`label_pl`,
+	`tag_pattern`,
+	`lemma_id`,
+	`state`,
+	`due`,
+	`stability`,
+	`difficulty`,
+	`elapsed_days`,
+	`scheduled_days`,
+	`reps`,
+	`lapses`,
+	`last_review`,
+	`created_at`
+)
+SELECT
+	`id`,
+	`kind`,
+	`label`,
+	`label_pl`,
+	`tag_pattern`,
+	`lemma_id`,
+	0,
+	unixepoch(),
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	NULL,
+	`created_at`
+FROM `knowledge_components`;--> statement-breakpoint
+DROP TABLE `knowledge_components`;--> statement-breakpoint
+ALTER TABLE `__new_knowledge_components` RENAME TO `knowledge_components`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `knowledge_components_kind_idx` ON `knowledge_components` (`kind`);--> statement-breakpoint
+CREATE INDEX `knowledge_components_lemma_id_idx` ON `knowledge_components` (`lemma_id`);

--- a/packages/db/migrations/meta/0014_snapshot.json
+++ b/packages/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1435 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3a82c5e8-7e32-44b7-92f9-f256e19d2e11",
+  "prevId": "4a7df5a1-965a-4288-ae4d-60da836c0fd9",
+  "tables": {
+    "card_knowledge_components": {
+      "name": "card_knowledge_components",
+      "columns": {
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kc_id": {
+          "name": "kc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "card_knowledge_components_kc_id_idx": {
+          "name": "card_knowledge_components_kc_id_idx",
+          "columns": [
+            "kc_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "card_knowledge_components_card_id_cards_id_fk": {
+          "name": "card_knowledge_components_card_id_cards_id_fk",
+          "tableFrom": "card_knowledge_components",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_knowledge_components_kc_id_knowledge_components_id_fk": {
+          "name": "card_knowledge_components_kc_id_knowledge_components_id_fk",
+          "tableFrom": "card_knowledge_components",
+          "tableTo": "knowledge_components",
+          "columnsFrom": [
+            "kc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "card_knowledge_components_card_id_kc_id_pk": {
+          "columns": [
+            "card_id",
+            "kc_id"
+          ],
+          "name": "card_knowledge_components_card_id_kc_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cards": {
+      "name": "cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'morph_form'"
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gap_id": {
+          "name": "gap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cards_due_idx": {
+          "name": "cards_due_idx",
+          "columns": [
+            "due"
+          ],
+          "isUnique": false
+        },
+        "cards_note_id_idx": {
+          "name": "cards_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cards_note_id_notes_id_fk": {
+          "name": "cards_note_id_notes_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cards_gap_id_cloze_gaps_id_fk": {
+          "name": "cards_gap_id_cloze_gaps_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "cloze_gaps",
+          "columnsFrom": [
+            "gap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "choice_options": {
+      "name": "choice_options",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "choice_options_note_id_notes_id_fk": {
+          "name": "choice_options_note_id_notes_id_fk",
+          "tableFrom": "choice_options",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloze_gaps": {
+      "name": "cloze_gaps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gap_index": {
+          "name": "gap_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answers": {
+          "name": "correct_answers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloze_gaps_note_id_notes_id_fk": {
+          "name": "cloze_gaps_note_id_notes_id_fk",
+          "tableFrom": "cloze_gaps",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloze_gaps_concept_id_grammar_concepts_id_fk": {
+          "name": "cloze_gaps_concept_id_grammar_concepts_id_fk",
+          "tableFrom": "cloze_gaps",
+          "tableTo": "grammar_concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "grammar_concepts": {
+      "name": "grammar_concepts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grammar_concepts_parent_id_grammar_concepts_id_fk": {
+          "name": "grammar_concepts_parent_id_grammar_concepts_id_fk",
+          "tableFrom": "grammar_concepts",
+          "tableTo": "grammar_concepts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_components": {
+      "name": "knowledge_components",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label_pl": {
+          "name": "label_pl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tag_pattern": {
+          "name": "tag_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_components_kind_idx": {
+          "name": "knowledge_components_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "knowledge_components_lemma_id_idx": {
+          "name": "knowledge_components_lemma_id_idx",
+          "columns": [
+            "lemma_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "knowledge_components_lemma_id_lemmas_id_fk": {
+          "name": "knowledge_components_lemma_id_lemmas_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lemmas": {
+      "name": "lemmas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'morfeusz'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_prompt": {
+          "name": "image_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "morph_forms": {
+      "name": "morph_forms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orth": {
+          "name": "orth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parsed_tag": {
+          "name": "parsed_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_path": {
+          "name": "audio_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "morph_forms_lemma_id_idx": {
+          "name": "morph_forms_lemma_id_idx",
+          "columns": [
+            "lemma_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "morph_forms_lemma_id_lemmas_id_fk": {
+          "name": "morph_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "morph_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "front": {
+          "name": "front",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "back": {
+          "name": "back",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sentence_id": {
+          "name": "sentence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'approved'"
+        },
+        "generation_meta": {
+          "name": "generation_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notes_lemma_id_idx": {
+          "name": "notes_lemma_id_idx",
+          "columns": [
+            "lemma_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notes_lemma_id_lemmas_id_fk": {
+          "name": "notes_lemma_id_lemmas_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notes_sentence_id_sentences_id_fk": {
+          "name": "notes_sentence_id_sentences_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "sentences",
+          "columnsFrom": [
+            "sentence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_concept_id_grammar_concepts_id_fk": {
+          "name": "notes_concept_id_grammar_concepts_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "grammar_concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_cluster_id_semantic_clusters_id_fk": {
+          "name": "notes_cluster_id_semantic_clusters_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "semantic_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_before": {
+          "name": "state_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due": {
+          "name": "due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability_after": {
+          "name": "stability_after",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty_after": {
+          "name": "difficulty_after",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_answer": {
+          "name": "user_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_question": {
+          "name": "generated_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_dimensions": {
+          "name": "error_dimensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_card_id_idx": {
+          "name": "reviews_card_id_idx",
+          "columns": [
+            "card_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_card_id_cards_id_fk": {
+          "name": "reviews_card_id_cards_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cluster_members": {
+      "name": "semantic_cluster_members",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "semantic_cluster_members_cluster_id_semantic_clusters_id_fk": {
+          "name": "semantic_cluster_members_cluster_id_semantic_clusters_id_fk",
+          "tableFrom": "semantic_cluster_members",
+          "tableTo": "semantic_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "semantic_cluster_members_lemma_id_lemmas_id_fk": {
+          "name": "semantic_cluster_members_lemma_id_lemmas_id_fk",
+          "tableFrom": "semantic_cluster_members",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "semantic_cluster_members_cluster_id_lemma_id_pk": {
+          "columns": [
+            "cluster_id",
+            "lemma_id"
+          ],
+          "name": "semantic_cluster_members_cluster_id_lemma_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_clusters": {
+      "name": "semantic_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_type": {
+          "name": "cluster_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentence_concepts": {
+      "name": "sentence_concepts",
+      "columns": {
+        "sentence_id": {
+          "name": "sentence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sentence_concepts_sentence_id_sentences_id_fk": {
+          "name": "sentence_concepts_sentence_id_sentences_id_fk",
+          "tableFrom": "sentence_concepts",
+          "tableTo": "sentences",
+          "columnsFrom": [
+            "sentence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sentence_concepts_concept_id_grammar_concepts_id_fk": {
+          "name": "sentence_concepts_concept_id_grammar_concepts_id_fk",
+          "tableFrom": "sentence_concepts",
+          "tableTo": "grammar_concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sentence_concepts_sentence_id_concept_id_pk": {
+          "columns": [
+            "sentence_id",
+            "concept_id"
+          ],
+          "name": "sentence_concepts_sentence_id_concept_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentences": {
+      "name": "sentences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'handcrafted'"
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vocab_list_notes": {
+      "name": "vocab_list_notes",
+      "columns": {
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vocab_list_notes_list_id_vocab_lists_id_fk": {
+          "name": "vocab_list_notes_list_id_vocab_lists_id_fk",
+          "tableFrom": "vocab_list_notes",
+          "tableTo": "vocab_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vocab_list_notes_note_id_notes_id_fk": {
+          "name": "vocab_list_notes_note_id_notes_id_fk",
+          "tableFrom": "vocab_list_notes",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vocab_list_notes_list_id_note_id_pk": {
+          "columns": [
+            "list_id",
+            "note_id"
+          ],
+          "name": "vocab_list_notes_list_id_note_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vocab_lists": {
+      "name": "vocab_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1774458777341,
       "tag": "0013_stale_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1776338809789,
+      "tag": "0014_steady_donald_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,6 +3,7 @@ export { createDb, db } from "./client.js";
 export type { DbClient } from "./client.js";
 export { tagMatchesKC, mapCardToKCs } from "./kc-engine.js";
 export type { KnowledgeComponent } from "./kc-engine.js";
+export { createInitialKnowledgeComponentFsrsState } from "./kc-fsrs.js";
 export { seedKCs } from "./kc-seed.js";
 export type { KCSeed, SeedKCsResult } from "./kc-seed.js";
 export { backfillKCs } from "./kc-backfill.js";

--- a/packages/db/src/kc-backfill.ts
+++ b/packages/db/src/kc-backfill.ts
@@ -7,6 +7,7 @@
  */
 import { eq } from "drizzle-orm";
 import type { DbClient } from "./client.js";
+import { createInitialKnowledgeComponentFsrsState } from "./kc-fsrs.js";
 import {
   knowledgeComponents,
   cardKnowledgeComponents,
@@ -69,6 +70,7 @@ export async function backfillKCs(db: DbClient): Promise<BackfillKCsResult> {
       let lemmaKC = lemmaKCByLemmaId.get(card.lemmaId);
       if (!lemmaKC) {
         const kcId = `kc-lemma-${card.lemmaId}`;
+        const fsrs = createInitialKnowledgeComponentFsrsState();
         db.insert(knowledgeComponents).values({
           id: kcId,
           kind: "lemma",
@@ -76,6 +78,7 @@ export async function backfillKCs(db: DbClient): Promise<BackfillKCsResult> {
           labelPl: null,
           tagPattern: null,
           lemmaId: card.lemmaId,
+          ...fsrs,
           createdAt: now,
         }).run();
         lemmaKC = {
@@ -85,6 +88,7 @@ export async function backfillKCs(db: DbClient): Promise<BackfillKCsResult> {
           labelPl: null,
           tagPattern: null,
           lemmaId: card.lemmaId,
+          ...fsrs,
           createdAt: now,
         };
         lemmaKCByLemmaId.set(card.lemmaId, lemmaKC);

--- a/packages/db/src/kc-engine.test.ts
+++ b/packages/db/src/kc-engine.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { createInitialKnowledgeComponentFsrsState } from "./kc-fsrs.js";
 import { tagMatchesKC, mapCardToKCs } from "./kc-engine.js";
 import type { KnowledgeComponent } from "./kc-engine.js";
 
@@ -11,6 +12,7 @@ function makeKC(overrides: Partial<KnowledgeComponent> & { id: string; kind: str
     labelPl: null,
     tagPattern: null,
     lemmaId: null,
+    ...createInitialKnowledgeComponentFsrsState(),
     createdAt: new Date(),
     ...overrides,
   } as KnowledgeComponent;

--- a/packages/db/src/kc-fsrs.ts
+++ b/packages/db/src/kc-fsrs.ts
@@ -1,0 +1,23 @@
+import { createCard } from "@rzyns/strus-core";
+
+/**
+ * Mirror the cards table's initial FSRS values for freshly created knowledge components.
+ * We intentionally reuse the same initializer that cards use, then drop card-only fields.
+ */
+export function createInitialKnowledgeComponentFsrsState() {
+  const card = createCard("__kc-bootstrap__", "morph_form");
+
+  return {
+    state: card.state,
+    due: Math.floor(card.due.getTime() / 1000),
+    stability: card.stability,
+    difficulty: card.difficulty,
+    elapsedDays: card.elapsedDays,
+    scheduledDays: card.scheduledDays,
+    reps: card.reps,
+    lapses: card.lapses,
+    lastReview: card.lastReview
+      ? Math.floor(card.lastReview.getTime() / 1000)
+      : null,
+  };
+}

--- a/packages/db/src/kc-seed.ts
+++ b/packages/db/src/kc-seed.ts
@@ -8,6 +8,7 @@
  */
 import { eq } from "drizzle-orm";
 import type { DbClient } from "./client.js";
+import { createInitialKnowledgeComponentFsrsState } from "./kc-fsrs.js";
 import { knowledgeComponents } from "./schema.js";
 
 // ---------------------------------------------------------------------------
@@ -104,6 +105,7 @@ export function seedKCs(db: DbClient): SeedKCsResult {
       continue;
     }
 
+    const fsrs = createInitialKnowledgeComponentFsrsState();
     db.insert(knowledgeComponents).values({
       id: seed.id,
       kind: seed.kind,
@@ -111,6 +113,7 @@ export function seedKCs(db: DbClient): SeedKCsResult {
       labelPl: seed.labelPl,
       tagPattern: seed.tagPattern,
       lemmaId: null,
+      ...fsrs,
       createdAt: now,
     }).run();
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -282,6 +282,18 @@ export const knowledgeComponents = sqliteTable(
     tagPattern: text("tag_pattern"),
     /** FK to lemmas.id — set for kind='lemma' only, null otherwise */
     lemmaId:    text("lemma_id").references(() => lemmas.id, { onDelete: "cascade" }),
+    /** CardState enum value (0=New,1=Learning,2=Review,3=Relearning) */
+    state:      integer("state").notNull().default(0),
+    /** Unix timestamp (seconds) */
+    due:        integer("due").notNull(),
+    stability:  real("stability").notNull().default(0),
+    difficulty: real("difficulty").notNull().default(0),
+    elapsedDays: integer("elapsed_days").notNull().default(0),
+    scheduledDays: integer("scheduled_days").notNull().default(0),
+    reps:       integer("reps").notNull().default(0),
+    lapses:     integer("lapses").notNull().default(0),
+    /** Unix timestamp (seconds), nullable */
+    lastReview: integer("last_review"),
     createdAt:  integer("created_at", { mode: "timestamp" }).notNull(),
   },
   (t) => [


### PR DESCRIPTION
## Summary
- add card-parity FSRS columns to `knowledge_components`
- add a safe SQLite rebuild migration for existing Phase 1 KC rows
- update KC seed/backfill/router/test insert sites to populate the new required fields

## Verification
- `bun run --filter @rzyns/strus-db test`
- `bun run --filter @rzyns/strus-db typecheck`
- `bun run --filter @rzyns/strus-api test`
- `bun run --filter @rzyns/strus-api typecheck`
- `bun run --filter @rzyns/strus-db generate`
- custom upgrade check: migrated a pre-0014 DB with an existing KC row through `0014_steady_donald_blake.sql`

## Caveat
- This branch is intentionally based on local `main` commit `5922d3e` (`fix(cli): allow empty test suite in workspace runs`), which is not on GitHub `main` yet.
- As a result, this PR currently includes that prerequisite base commit plus the STR-19 commit.
