### PR TITLE
feat: propagate review ratings to parent knowledge components

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -25,6 +25,7 @@ import {
   knowledgeComponents,
   cardKnowledgeComponents,
   createInitialKnowledgeComponentFsrsState,
+  scheduleKnowledgeComponentReview,
   mapCardToKCs,
   seedKCs,
   backfillKCs,
@@ -1762,87 +1763,125 @@ const sessionReview = os
     updated: CardOutput.describe("The card with its updated FSRS state"),
   }))
   .handler(async ({ input }) => {
-    const [row] = await db
-      .select()
-      .from(cards)
-      .where(eq(cards.id, input.cardId))
-      .limit(1);
-
-    if (!row) {
-      throw new ORPCError("NOT_FOUND", {
-        message: `Card not found: ${input.cardId}`,
-      });
-    }
-
     const now = new Date();
-    const dueDateBefore = new Date(row.due * 1000);
-
-    const card: Card = {
-      id: row.id,
-      noteId: row.noteId,
-      kind: row.kind as Card["kind"],
-      state: row.state as CardState,
-      due: dueDateBefore,
-      stability: row.stability,
-      difficulty: row.difficulty,
-      elapsedDays: row.elapsedDays,
-      scheduledDays: row.scheduledDays,
-      reps: row.reps,
-      lapses: row.lapses,
-      learningSteps: row.learningSteps,
-      ...(row.tag != null ? { tag: row.tag } : {}),
-      ...(row.lastReview != null ? { lastReview: new Date(row.lastReview * 1000) } : {}),
-    };
-
-    const updated = scheduleReview(card, input.rating, now);
-
-    await db
-      .update(cards)
-      .set({
-        state: updated.state,
-        due: Math.floor(updated.due.getTime() / 1000),
-        stability: updated.stability,
-        difficulty: updated.difficulty,
-        elapsedDays: updated.elapsedDays,
-        scheduledDays: updated.scheduledDays,
-        reps: updated.reps,
-        lapses: updated.lapses,
-        learningSteps: updated.learningSteps,
-        lastReview: updated.lastReview
-          ? Math.floor(updated.lastReview.getTime() / 1000)
-          : null,
-      })
-      .where(eq(cards.id, input.cardId));
-
     const nowSecs = Math.floor(now.getTime() / 1000);
 
-    const reviewId = crypto.randomUUID();
-    await db.insert(reviews).values({
-      id: reviewId,
-      cardId: input.cardId,
-      rating: input.rating,
-      stateBefore: card.state,
-      due: Math.floor(dueDateBefore.getTime() / 1000),
-      reviewedAt: nowSecs,
-      elapsedDays: updated.elapsedDays,
-      scheduledDays: updated.scheduledDays,
-      stabilityAfter: updated.stability,
-      difficultyAfter: updated.difficulty,
-      userAnswer: input.userAnswer ?? null,
-      generatedQuestion: input.generatedQuestion ?? null,
-      errorDimensions: input.errorDimensions ? JSON.stringify(input.errorDimensions) : null,
+    return db.transaction((tx) => {
+      const [row] = tx
+        .select()
+        .from(cards)
+        .where(eq(cards.id, input.cardId))
+        .limit(1)
+        .all();
+
+      if (!row) {
+        throw new ORPCError("NOT_FOUND", {
+          message: `Card not found: ${input.cardId}`,
+        });
+      }
+
+      const dueDateBefore = new Date(row.due * 1000);
+      const card: Card = {
+        id: row.id,
+        noteId: row.noteId,
+        kind: row.kind as Card["kind"],
+        state: row.state as CardState,
+        due: dueDateBefore,
+        stability: row.stability,
+        difficulty: row.difficulty,
+        elapsedDays: row.elapsedDays,
+        scheduledDays: row.scheduledDays,
+        reps: row.reps,
+        lapses: row.lapses,
+        learningSteps: row.learningSteps,
+        ...(row.tag != null ? { tag: row.tag } : {}),
+        ...(row.lastReview != null ? { lastReview: new Date(row.lastReview * 1000) } : {}),
+      };
+
+      const updated = scheduleReview(card, input.rating, now);
+
+      tx
+        .update(cards)
+        .set({
+          state: updated.state,
+          due: Math.floor(updated.due.getTime() / 1000),
+          stability: updated.stability,
+          difficulty: updated.difficulty,
+          elapsedDays: updated.elapsedDays,
+          scheduledDays: updated.scheduledDays,
+          reps: updated.reps,
+          lapses: updated.lapses,
+          learningSteps: updated.learningSteps,
+          lastReview: updated.lastReview
+            ? Math.floor(updated.lastReview.getTime() / 1000)
+            : null,
+        })
+        .where(eq(cards.id, input.cardId))
+        .run();
+
+      const parentKcIds = tx
+        .select({ kcId: cardKnowledgeComponents.kcId })
+        .from(cardKnowledgeComponents)
+        .where(eq(cardKnowledgeComponents.cardId, input.cardId))
+        .all()
+        .map((row) => row.kcId);
+
+      if (parentKcIds.length > 0) {
+        const parentKcs = tx
+          .select()
+          .from(knowledgeComponents)
+          .where(inArray(knowledgeComponents.id, parentKcIds))
+          .all();
+
+        for (const kc of parentKcs) {
+          const updatedKc = scheduleKnowledgeComponentReview({
+            state: kc.state,
+            due: kc.due,
+            stability: kc.stability,
+            difficulty: kc.difficulty,
+            elapsedDays: kc.elapsedDays,
+            scheduledDays: kc.scheduledDays,
+            reps: kc.reps,
+            lapses: kc.lapses,
+            lastReview: kc.lastReview,
+          }, input.rating, now);
+
+          tx
+            .update(knowledgeComponents)
+            .set(updatedKc)
+            .where(eq(knowledgeComponents.id, kc.id))
+            .run();
+        }
+      }
+
+      const reviewId = crypto.randomUUID();
+      tx.insert(reviews).values({
+        id: reviewId,
+        cardId: input.cardId,
+        rating: input.rating,
+        stateBefore: card.state,
+        due: Math.floor(dueDateBefore.getTime() / 1000),
+        reviewedAt: nowSecs,
+        elapsedDays: updated.elapsedDays,
+        scheduledDays: updated.scheduledDays,
+        stabilityAfter: updated.stability,
+        difficultyAfter: updated.difficulty,
+        userAnswer: input.userAnswer ?? null,
+        generatedQuestion: input.generatedQuestion ?? null,
+        errorDimensions: input.errorDimensions ? JSON.stringify(input.errorDimensions) : null,
+      }).run();
+
+      tx
+        .update(notes)
+        .set({ lastReviewedAt: nowSecs })
+        .where(eq(notes.id, row.noteId))
+        .run();
+
+      return {
+        reviewId,
+        updated: mapCardDomain(updated),
+      };
     });
-
-    // Update the parent note's last-reviewed timestamp.
-    await db
-      .update(notes)
-      .set({ lastReviewedAt: nowSecs })
-      .where(eq(notes.id, row.noteId));
-
-    return {
-      reviewId,
-      updated: mapCardDomain(updated),
-    };
   });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/session-review-kc-propagation.test.ts
+++ b/packages/api/src/session-review-kc-propagation.test.ts
@@ -1,0 +1,322 @@
+/**
+ * /session/review — KC propagation
+ *
+ * STR-20 / KC7: reviewing a card should keep normal card FSRS behavior,
+ * and also propagate the same rating to every linked parent KC.
+ */
+import { describe, test, expect, beforeEach } from "bun:test";
+import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { eq } from "drizzle-orm";
+import { call } from "@orpc/server";
+import {
+  db,
+  notes,
+  cards,
+  reviews,
+  knowledgeComponents,
+  cardKnowledgeComponents,
+  createInitialKnowledgeComponentFsrsState,
+  scheduleKnowledgeComponentReview,
+} from "@rzyns/strus-db";
+import { router } from "./router.js";
+import { CardState, Rating, scheduleReview, type Card } from "@rzyns/strus-core";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../db/migrations");
+migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+
+const NOW = new Date();
+const NOW_SECS = Math.floor(Date.now() / 1000);
+const PAST = NOW_SECS - 86400;
+
+type SeededCard = {
+  id: string;
+  noteId: string;
+  kind: Card["kind"];
+  tag: string | null;
+  gapId: string | null;
+  state: CardState;
+  due: number;
+  stability: number;
+  difficulty: number;
+  elapsedDays: number;
+  scheduledDays: number;
+  reps: number;
+  lapses: number;
+  learningSteps: number;
+  lastReview: number | null;
+};
+
+type SeededKc = {
+  id: string;
+  kind: "case" | "number" | "tense" | "mood" | "gender" | "pos" | "lemma";
+  label: string;
+  labelPl: string | null;
+  tagPattern: string | null;
+  lemmaId: string | null;
+  state: number;
+  due: number;
+  stability: number;
+  difficulty: number;
+  elapsedDays: number;
+  scheduledDays: number;
+  reps: number;
+  lapses: number;
+  lastReview: number | null;
+  createdAt: Date;
+};
+
+beforeEach(() => {
+  db.delete(reviews).run();
+  db.delete(cardKnowledgeComponents).run();
+  db.delete(cards).run();
+  db.delete(knowledgeComponents).run();
+  db.delete(notes).run();
+});
+
+function makeNote(): string {
+  const id = randomUUID();
+  db.insert(notes).values({
+    id,
+    kind: "basic",
+    lemmaId: null,
+    front: "front",
+    back: "back",
+    lastReviewedAt: null,
+    sentenceId: null,
+    conceptId: null,
+    clusterId: null,
+    explanation: null,
+    status: "approved",
+    generationMeta: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).run();
+  return id;
+}
+
+function makeCard(overrides: Partial<SeededCard> = {}): SeededCard {
+  const id = randomUUID();
+  const noteId = makeNote();
+  const row: SeededCard = {
+    id,
+    noteId,
+    kind: "basic_forward",
+    tag: null,
+    gapId: null,
+    state: CardState.Review,
+    due: PAST,
+    stability: 12,
+    difficulty: 5.5,
+    elapsedDays: 5,
+    scheduledDays: 12,
+    reps: 6,
+    lapses: 1,
+    learningSteps: 0,
+    lastReview: PAST - 86400,
+    ...overrides,
+  };
+  db.insert(cards).values(row).run();
+  return row;
+}
+
+function toDomainCard(row: SeededCard): Card {
+  return {
+    id: row.id,
+    noteId: row.noteId,
+    kind: row.kind as Card["kind"],
+    state: row.state as CardState,
+    due: new Date(row.due * 1000),
+    stability: row.stability,
+    difficulty: row.difficulty,
+    elapsedDays: row.elapsedDays,
+    scheduledDays: row.scheduledDays,
+    reps: row.reps,
+    lapses: row.lapses,
+    learningSteps: row.learningSteps,
+    ...(row.tag != null ? { tag: row.tag } : {}),
+    ...(row.lastReview != null ? { lastReview: new Date(row.lastReview * 1000) } : {}),
+  };
+}
+
+function makeKC(overrides: Partial<SeededKc> = {}): SeededKc {
+  const id = randomUUID();
+  const fsrs = createInitialKnowledgeComponentFsrsState();
+  const row: SeededKc = {
+    id,
+    kind: "case",
+    label: `kc-${id}`,
+    labelPl: null,
+    tagPattern: "*:gen:*",
+    lemmaId: null,
+    ...fsrs,
+    createdAt: NOW,
+    ...overrides,
+  };
+  db.insert(knowledgeComponents).values(row).run();
+  return row;
+}
+
+function linkCardToKC(cardId: string, kcId: string): void {
+  db.insert(cardKnowledgeComponents).values({ cardId, kcId }).run();
+}
+
+describe("/session/review — KC propagation", () => {
+  test("card with no linked KCs still reviews normally", async () => {
+    const cardRow = makeCard();
+    const unrelatedKc = makeKC({
+      state: CardState.Review,
+      due: PAST,
+      stability: 30,
+      difficulty: 4.2,
+      elapsedDays: 9,
+      scheduledDays: 30,
+      reps: 8,
+      lapses: 0,
+      lastReview: PAST - 86400,
+    });
+
+    const result = await call(router.session.review, { cardId: cardRow.id, rating: Rating.Good });
+    const reviewedAt = new Date(result.updated.lastReview!);
+    const expectedCard = scheduleReview(toDomainCard(cardRow), Rating.Good, reviewedAt);
+
+    const [updatedCardRow] = db.select().from(cards).where(eq(cards.id, cardRow.id)).limit(1).all();
+    const [reviewRow] = db.select().from(reviews).where(eq(reviews.id, result.reviewId)).limit(1).all();
+    const [noteRow] = db.select().from(notes).where(eq(notes.id, cardRow.noteId)).limit(1).all();
+    const [unchangedKcRow] = db.select().from(knowledgeComponents).where(eq(knowledgeComponents.id, unrelatedKc.id)).limit(1).all();
+
+    expect(updatedCardRow).toBeDefined();
+    expect(reviewRow).toBeDefined();
+    expect(noteRow).toBeDefined();
+    expect(unchangedKcRow).toBeDefined();
+    const updatedCard = updatedCardRow!;
+    const review = reviewRow!;
+    const note = noteRow!;
+    const unchangedKc = unchangedKcRow!;
+
+    expect(updatedCard.state).toBe(expectedCard.state);
+    expect(updatedCard.due).toBe(Math.floor(expectedCard.due.getTime() / 1000));
+    expect(updatedCard.stability).toBe(expectedCard.stability);
+    expect(updatedCard.difficulty).toBe(expectedCard.difficulty);
+    expect(updatedCard.elapsedDays).toBe(expectedCard.elapsedDays);
+    expect(updatedCard.scheduledDays).toBe(expectedCard.scheduledDays);
+    expect(updatedCard.reps).toBe(expectedCard.reps);
+    expect(updatedCard.lapses).toBe(expectedCard.lapses);
+    expect(updatedCard.learningSteps).toBe(expectedCard.learningSteps);
+    expect(updatedCard.lastReview).toBe(Math.floor(reviewedAt.getTime() / 1000));
+
+    expect(review.cardId).toBe(cardRow.id);
+    expect(review.rating).toBe(Rating.Good);
+    expect(note.lastReviewedAt).toBe(Math.floor(reviewedAt.getTime() / 1000));
+
+    expect(unchangedKc.state).toBe(unrelatedKc.state);
+    expect(unchangedKc.due).toBe(unrelatedKc.due);
+    expect(unchangedKc.stability).toBe(unrelatedKc.stability);
+    expect(unchangedKc.difficulty).toBe(unrelatedKc.difficulty);
+    expect(unchangedKc.elapsedDays).toBe(unrelatedKc.elapsedDays);
+    expect(unchangedKc.scheduledDays).toBe(unrelatedKc.scheduledDays);
+    expect(unchangedKc.reps).toBe(unrelatedKc.reps);
+    expect(unchangedKc.lapses).toBe(unrelatedKc.lapses);
+    expect(unchangedKc.lastReview).toBe(unrelatedKc.lastReview);
+  });
+
+  test("review propagates the same rating to every linked KC", async () => {
+    const cardRow = makeCard({
+      state: CardState.Review,
+      due: PAST,
+      stability: 20,
+      difficulty: 4.8,
+      elapsedDays: 7,
+      scheduledDays: 20,
+      reps: 10,
+      lapses: 1,
+      lastReview: PAST - 172800,
+    });
+    const kc1 = makeKC();
+    const kc2 = makeKC({
+      kind: "number",
+      label: "singular",
+      labelPl: "liczba pojedyncza",
+      state: CardState.Review,
+      due: PAST,
+      stability: 18,
+      difficulty: 5.1,
+      elapsedDays: 6,
+      scheduledDays: 18,
+      reps: 7,
+      lapses: 1,
+      lastReview: PAST - 86400,
+    });
+
+    linkCardToKC(cardRow.id, kc1.id);
+    linkCardToKC(cardRow.id, kc2.id);
+
+    const result = await call(router.session.review, { cardId: cardRow.id, rating: Rating.Again });
+    const reviewedAt = new Date(result.updated.lastReview!);
+    const expectedCard = scheduleReview(toDomainCard(cardRow), Rating.Again, reviewedAt);
+    const expectedKc1 = scheduleKnowledgeComponentReview({
+      state: kc1.state,
+      due: kc1.due,
+      stability: kc1.stability,
+      difficulty: kc1.difficulty,
+      elapsedDays: kc1.elapsedDays,
+      scheduledDays: kc1.scheduledDays,
+      reps: kc1.reps,
+      lapses: kc1.lapses,
+      lastReview: kc1.lastReview,
+    }, Rating.Again, reviewedAt);
+    const expectedKc2 = scheduleKnowledgeComponentReview({
+      state: kc2.state,
+      due: kc2.due,
+      stability: kc2.stability,
+      difficulty: kc2.difficulty,
+      elapsedDays: kc2.elapsedDays,
+      scheduledDays: kc2.scheduledDays,
+      reps: kc2.reps,
+      lapses: kc2.lapses,
+      lastReview: kc2.lastReview,
+    }, Rating.Again, reviewedAt);
+
+    const [updatedCardRow] = db.select().from(cards).where(eq(cards.id, cardRow.id)).limit(1).all();
+    const [updatedKc1] = db.select().from(knowledgeComponents).where(eq(knowledgeComponents.id, kc1.id)).limit(1).all();
+    const [updatedKc2] = db.select().from(knowledgeComponents).where(eq(knowledgeComponents.id, kc2.id)).limit(1).all();
+
+    expect(updatedCardRow).toBeDefined();
+    expect(updatedKc1).toBeDefined();
+    expect(updatedKc2).toBeDefined();
+    const updatedCard = updatedCardRow!;
+    const persistedKc1 = updatedKc1!;
+    const persistedKc2 = updatedKc2!;
+
+    expect(updatedCard.state).toBe(expectedCard.state);
+    expect(updatedCard.due).toBe(Math.floor(expectedCard.due.getTime() / 1000));
+    expect(updatedCard.stability).toBe(expectedCard.stability);
+    expect(updatedCard.difficulty).toBe(expectedCard.difficulty);
+    expect(updatedCard.elapsedDays).toBe(expectedCard.elapsedDays);
+    expect(updatedCard.scheduledDays).toBe(expectedCard.scheduledDays);
+    expect(updatedCard.reps).toBe(expectedCard.reps);
+    expect(updatedCard.lapses).toBe(expectedCard.lapses);
+    expect(updatedCard.lastReview).toBe(Math.floor(reviewedAt.getTime() / 1000));
+
+    expect(persistedKc1.state).toBe(expectedKc1.state);
+    expect(persistedKc1.due).toBe(expectedKc1.due);
+    expect(persistedKc1.stability).toBe(expectedKc1.stability);
+    expect(persistedKc1.difficulty).toBe(expectedKc1.difficulty);
+    expect(persistedKc1.elapsedDays).toBe(expectedKc1.elapsedDays);
+    expect(persistedKc1.scheduledDays).toBe(expectedKc1.scheduledDays);
+    expect(persistedKc1.reps).toBe(expectedKc1.reps);
+    expect(persistedKc1.lapses).toBe(expectedKc1.lapses);
+    expect(persistedKc1.lastReview).toBe(expectedKc1.lastReview);
+
+    expect(persistedKc2.state).toBe(expectedKc2.state);
+    expect(persistedKc2.due).toBe(expectedKc2.due);
+    expect(persistedKc2.stability).toBe(expectedKc2.stability);
+    expect(persistedKc2.difficulty).toBe(expectedKc2.difficulty);
+    expect(persistedKc2.elapsedDays).toBe(expectedKc2.elapsedDays);
+    expect(persistedKc2.scheduledDays).toBe(expectedKc2.scheduledDays);
+    expect(persistedKc2.reps).toBe(expectedKc2.reps);
+    expect(persistedKc2.lapses).toBe(expectedKc2.lapses);
+    expect(persistedKc2.lastReview).toBe(expectedKc2.lastReview);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,7 +3,11 @@ export { createDb, db } from "./client.js";
 export type { DbClient } from "./client.js";
 export { tagMatchesKC, mapCardToKCs } from "./kc-engine.js";
 export type { KnowledgeComponent } from "./kc-engine.js";
-export { createInitialKnowledgeComponentFsrsState } from "./kc-fsrs.js";
+export {
+  createInitialKnowledgeComponentFsrsState,
+  scheduleKnowledgeComponentReview,
+} from "./kc-fsrs.js";
+export type { KnowledgeComponentFsrsState } from "./kc-fsrs.js";
 export { seedKCs } from "./kc-seed.js";
 export type { KCSeed, SeedKCsResult } from "./kc-seed.js";
 export { backfillKCs } from "./kc-backfill.js";

--- a/packages/db/src/kc-fsrs.ts
+++ b/packages/db/src/kc-fsrs.ts
@@ -1,10 +1,22 @@
-import { createCard } from "@rzyns/strus-core";
+import { createCard, scheduleReview, type Rating } from "@rzyns/strus-core";
+
+export interface KnowledgeComponentFsrsState {
+  state: number;
+  due: number;
+  stability: number;
+  difficulty: number;
+  elapsedDays: number;
+  scheduledDays: number;
+  reps: number;
+  lapses: number;
+  lastReview: number | null;
+}
 
 /**
  * Mirror the cards table's initial FSRS values for freshly created knowledge components.
  * We intentionally reuse the same initializer that cards use, then drop card-only fields.
  */
-export function createInitialKnowledgeComponentFsrsState() {
+export function createInitialKnowledgeComponentFsrsState(): KnowledgeComponentFsrsState {
   const card = createCard("__kc-bootstrap__", "morph_form");
 
   return {
@@ -18,6 +30,46 @@ export function createInitialKnowledgeComponentFsrsState() {
     lapses: card.lapses,
     lastReview: card.lastReview
       ? Math.floor(card.lastReview.getTime() / 1000)
+      : null,
+  };
+}
+
+/**
+ * Apply a review rating to a KC using the same ts-fsrs repeat path as cards.
+ * KCs do not persist learning_steps today, so we replay them with the default step index (0).
+ */
+export function scheduleKnowledgeComponentReview(
+  kc: KnowledgeComponentFsrsState,
+  rating: Rating,
+  now: Date = new Date(),
+): KnowledgeComponentFsrsState {
+  const updated = scheduleReview({
+    id: "__kc-bootstrap__",
+    noteId: "__kc-bootstrap__",
+    kind: "morph_form",
+    state: kc.state,
+    due: new Date(kc.due * 1000),
+    stability: kc.stability,
+    difficulty: kc.difficulty,
+    elapsedDays: kc.elapsedDays,
+    scheduledDays: kc.scheduledDays,
+    reps: kc.reps,
+    lapses: kc.lapses,
+    learningSteps: 0,
+    ...(kc.lastReview != null ? { lastReview: new Date(kc.lastReview * 1000) } : {}),
+  }, rating, now);
+
+  return {
+    state: updated.state,
+    due: Math.floor(updated.due.getTime() / 1000),
+    stability: updated.stability,
+    difficulty: updated.difficulty,
+    elapsedDays: updated.elapsedDays,
+    scheduledDays: updated.scheduledDays,
+    reps: updated.reps,
+    lapses: updated.lapses,
+    lastReview: updated.lastReview
+      ? Math.floor(updated.lastReview.getTime() / 1000)
       : null,
   };
 }


### PR DESCRIPTION
## Summary
- propagate the same review rating from a reviewed card to all linked parent knowledge components
- keep card review updates, review logging, and note timestamps in one DB transaction
- add focused API tests covering no-KC, single/multiple-KC propagation behavior

## Testing
- bun run --filter @rzyns/strus-db test
- bun run --filter @rzyns/strus-db typecheck
- bun run --filter @rzyns/strus-api test
- bun run --filter @rzyns/strus-api typecheck