### PR TITLE
STR-21: prioritize sessions by overdue knowledge components

### DIFF
--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1138,6 +1138,109 @@ function shuffle<T>(arr: T[]): T[] {
   return arr;
 }
 
+type SessionCandidateRow = {
+  card: typeof cards.$inferSelect;
+  lemmaId: string | null;
+  lemmaText: string | null;
+  front: string | null;
+  back: string | null;
+};
+
+/**
+ * Today's structural focus is the most-overdue non-lemma KC among the current
+ * candidate cards. Cards linked to that KC are served first, then cards linked
+ * to any other overdue structural KC, then everything else.
+ */
+function buildKcPriorityContext<T extends { card: { id: string } }>(items: T[], nowSecs: number): {
+  focusCardIds: Set<string>;
+  overdueStructuralCardIds: Set<string>;
+} {
+  const cardIds = [...new Set(items.map((item) => item.card.id))];
+  if (cardIds.length === 0) {
+    return {
+      focusCardIds: new Set<string>(),
+      overdueStructuralCardIds: new Set<string>(),
+    };
+  }
+
+  const linkedOverdueKcs = db
+    .select({
+      cardId: cardKnowledgeComponents.cardId,
+      kcId: knowledgeComponents.id,
+      kcDue: knowledgeComponents.due,
+      kcStability: knowledgeComponents.stability,
+    })
+    .from(cardKnowledgeComponents)
+    .innerJoin(knowledgeComponents, eq(knowledgeComponents.id, cardKnowledgeComponents.kcId))
+    .where(and(
+      inArray(cardKnowledgeComponents.cardId, cardIds),
+      ne(knowledgeComponents.kind, "lemma"),
+      lte(knowledgeComponents.due, nowSecs),
+    ))
+    .all();
+
+  if (linkedOverdueKcs.length === 0) {
+    return {
+      focusCardIds: new Set<string>(),
+      overdueStructuralCardIds: new Set<string>(),
+    };
+  }
+
+  const overdueStructuralCardIds = new Set<string>();
+  const overdueKcs = new Map<string, { due: number; stability: number }>();
+  for (const row of linkedOverdueKcs) {
+    overdueStructuralCardIds.add(row.cardId);
+    if (!overdueKcs.has(row.kcId)) {
+      overdueKcs.set(row.kcId, {
+        due: row.kcDue,
+        stability: row.kcStability,
+      });
+    }
+  }
+
+  const [focusKcId] = [...overdueKcs.entries()]
+    .sort((a, b) => a[1].due - b[1].due || a[1].stability - b[1].stability || a[0].localeCompare(b[0]))[0]!;
+
+  const focusCardIds = new Set(
+    linkedOverdueKcs
+      .filter((row) => row.kcId === focusKcId)
+      .map((row) => row.cardId),
+  );
+
+  return { focusCardIds, overdueStructuralCardIds };
+}
+
+function prioritizeSessionCandidates<T extends { card: { id: string }; lemmaId: string | null }>(
+  items: T[],
+  nowSecs: number,
+  interleave: boolean,
+): T[] {
+  if (items.length <= 1) return items;
+
+  const { focusCardIds, overdueStructuralCardIds } = buildKcPriorityContext(items, nowSecs);
+  if (overdueStructuralCardIds.size === 0) {
+    return interleave ? interleaveByLemma(items) : items;
+  }
+
+  const focus: T[] = [];
+  const overdue: T[] = [];
+  const rest: T[] = [];
+
+  for (const item of items) {
+    if (focusCardIds.has(item.card.id)) {
+      focus.push(item);
+    } else if (overdueStructuralCardIds.has(item.card.id)) {
+      overdue.push(item);
+    } else {
+      rest.push(item);
+    }
+  }
+
+  const maybeInterleave = (bucket: T[]) => (interleave && bucket.length > 1 ? interleaveByLemma(bucket) : bucket);
+
+  return [...maybeInterleave(focus), ...maybeInterleave(overdue), ...maybeInterleave(rest)];
+}
+
 const sessionDue = os
   .route({
     method: "GET",
@@ -1224,15 +1327,7 @@ const sessionDue = os
         : []),
     ];
 
-    type RawRow = {
-      card: typeof cards.$inferSelect;
-      lemmaId: string | null;
-      lemmaText: string | null;
-      front: string | null;
-      back: string | null;
-    };
-
-    let session: RawRow[];
+    let session: SessionCandidateRow[];
 
     if (input.mode === "note-first") {
       // -----------------------------------------------------------------
@@ -1304,7 +1399,7 @@ const sessionDue = os
             .all();
 
       // Step 2b: group by note, cap cardsPerNote, enforce newLimit across session.
-      const byNote = new Map<string, RawRow[]>();
+      const byNote = new Map<string, SessionCandidateRow[]>();
       for (const r of rawDue) {
         const g = byNote.get(r.card.noteId);
         if (g !== undefined) g.push(r);
@@ -1312,7 +1407,7 @@ const sessionDue = os
       }
 
       let newCount = 0;
-      const collected: RawRow[] = [];
+      const collected: SessionCandidateRow[] = [];
       // Iterate in the same order as selectedNotes to preserve priority.
       for (const { noteId } of selectedNotes) {
         const noteCards = byNote.get(noteId);
@@ -1395,12 +1490,11 @@ const sessionDue = os
       // Shuffle reviews too so the order isn't purely by insertion date.
       shuffle(reviewPool);
 
-      let combined = [...reviewPool, ...newCards];
-
-      // Interleave by lemma: round-robin so forms of the same word are spread out.
-      if (input.interleave && combined.length > 1) {
-        combined = interleaveByLemma(combined);
-      }
+      const combined = prioritizeSessionCandidates(
+        [...reviewPool, ...newCards],
+        nowSecs,
+        input.interleave,
+      );
 
       session = combined.slice(0, input.limit);
     }
@@ -4146,10 +4240,10 @@ const sessionTargeted = os
     method: "POST",
     path: "/session/targeted",
     tags: ["Session"],
-    summary: "Get a targeted quiz session filtered by concept and/or card kind",
+    summary: "Get a targeted quiz session filtered by concept, KC, and/or card kind",
     description:
-      "Returns due cards filtered by grammar concept and/or card kind. " +
-      "All filters are optional. Uses the same FSRS due-date ordering as /session/due. " +
+      "Returns due cards filtered by grammar concept, knowledge component, and/or card kind. " +
+      "All filters are optional. Uses the same KC-aware prioritization as /session/due. " +
       "New cards are capped at newLimit. Only approved notes are included.",
   })
   .input(z.object({
@@ -4204,10 +4298,11 @@ const sessionTargeted = os
 
     shuffle(reviewPool);
 
-    let combined = [...reviewPool, ...newCards];
-    if (combined.length > 1) {
-      combined = interleaveByLemma(combined);
-    }
+    const combined = prioritizeSessionCandidates(
+      [...reviewPool, ...newCards],
+      nowSecs,
+      true,
+    );
 
     const session = combined.slice(0, input.limit);
 

--- a/packages/api/src/session-kc-priority.test.ts
+++ b/packages/api/src/session-kc-priority.test.ts
@@ -1,0 +1,192 @@
+/**
+ * /session/due + /session/targeted — KC-driven session composition
+ *
+ * STR-21 regression coverage:
+ * - the most-overdue structural KC becomes today's focus for due sessions
+ * - targeted sessions can explicitly filter by kcId
+ */
+import { describe, test, expect } from "bun:test";
+import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { call } from "@orpc/server";
+import { db } from "@rzyns/strus-db";
+import {
+  cards,
+  notes,
+  knowledgeComponents,
+  cardKnowledgeComponents,
+  createInitialKnowledgeComponentFsrsState,
+  vocabLists,
+  vocabListNotes,
+} from "@rzyns/strus-db";
+import { router } from "./router.js";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../db/migrations");
+migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+
+const NOW = new Date();
+const NOW_SECS = Math.floor(Date.now() / 1000);
+const CARD_PAST_DUE = NOW_SECS - 3600;
+
+function makeNote(status: "approved" | "draft" | "flagged" | "rejected" = "approved"): string {
+  const id = randomUUID();
+  db.insert(notes).values({
+    id,
+    kind: "cloze",
+    lemmaId: null,
+    front: null,
+    back: null,
+    sentenceId: null,
+    conceptId: null,
+    clusterId: null,
+    explanation: null,
+    status,
+    generationMeta: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }).run();
+  return id;
+}
+
+function makeCard(noteId: string, due = CARD_PAST_DUE): string {
+  const id = randomUUID();
+  db.insert(cards).values({
+    id,
+    noteId,
+    kind: "cloze_fill",
+    tag: null,
+    gapId: null,
+    state: 2,
+    due,
+    stability: 10,
+    difficulty: 5,
+    elapsedDays: 1,
+    scheduledDays: 1,
+    reps: 3,
+    lapses: 0,
+    learningSteps: 0,
+    lastReview: due - 86400,
+  }).run();
+  return id;
+}
+
+function makeKC(opts: {
+  kind?: "case" | "number" | "tense" | "mood" | "gender" | "pos" | "lemma";
+  label: string;
+  due: number;
+  stability?: number;
+}): string {
+  const id = randomUUID();
+  const fsrs = createInitialKnowledgeComponentFsrsState();
+  db.insert(knowledgeComponents).values({
+    id,
+    kind: opts.kind ?? "case",
+    label: opts.label,
+    labelPl: null,
+    tagPattern: "*:gen:*",
+    lemmaId: null,
+    ...fsrs,
+    due: opts.due,
+    stability: opts.stability ?? fsrs.stability,
+    createdAt: NOW,
+  }).run();
+  return id;
+}
+
+function linkCardToKC(cardId: string, kcId: string): void {
+  db.insert(cardKnowledgeComponents).values({ cardId, kcId }).run();
+}
+
+function makeList(): string {
+  const id = randomUUID();
+  db.insert(vocabLists).values({
+    id,
+    name: `kc-priority-${id}`,
+    description: null,
+    createdAt: NOW,
+  }).run();
+  return id;
+}
+
+function addNoteToList(listId: string, noteId: string): void {
+  db.insert(vocabListNotes).values({ listId, noteId }).run();
+}
+
+describe("/session/due — KC focus priority", () => {
+  test("cards linked to the most-overdue structural KC are served first", async () => {
+    const listId = makeList();
+
+    const mostOverdueNoteId = makeNote("approved");
+    addNoteToList(listId, mostOverdueNoteId);
+    const mostOverdueCardId = makeCard(mostOverdueNoteId);
+
+    const lessOverdueNoteId = makeNote("approved");
+    addNoteToList(listId, lessOverdueNoteId);
+    const lessOverdueCardId = makeCard(lessOverdueNoteId);
+
+    const mostOverdueKcId = makeKC({
+      kind: "case",
+      label: `focus-case-${randomUUID()}`,
+      due: NOW_SECS - 7 * 86400,
+      stability: 12,
+    });
+    const lessOverdueKcId = makeKC({
+      kind: "case",
+      label: `secondary-case-${randomUUID()}`,
+      due: NOW_SECS - 3600,
+      stability: 1,
+    });
+
+    linkCardToKC(mostOverdueCardId, mostOverdueKcId);
+    linkCardToKC(lessOverdueCardId, lessOverdueKcId);
+
+    const result = await call(router.session.due, {
+      listId,
+      limit: 1,
+      newLimit: 0,
+      interleave: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(mostOverdueCardId);
+    expect(result[0]!.id).not.toBe(lessOverdueCardId);
+  });
+});
+
+describe("/session/targeted — kcId filter", () => {
+  test("kcId filter returns only cards linked to that knowledge component", async () => {
+    const targetNoteId = makeNote("approved");
+    const targetCardId = makeCard(targetNoteId);
+
+    const otherNoteId = makeNote("approved");
+    const otherCardId = makeCard(otherNoteId);
+
+    const unlinkedNoteId = makeNote("approved");
+    const unlinkedCardId = makeCard(unlinkedNoteId);
+
+    const targetKcId = makeKC({
+      kind: "case",
+      label: `target-kc-${randomUUID()}`,
+      due: NOW_SECS - 86400,
+    });
+    const otherKcId = makeKC({
+      kind: "case",
+      label: `other-kc-${randomUUID()}`,
+      due: NOW_SECS - 86400,
+    });
+
+    linkCardToKC(targetCardId, targetKcId);
+    linkCardToKC(otherCardId, otherKcId);
+
+    const result = await call(router.session.targeted, {
+      kcId: targetKcId,
+      limit: 100,
+      newLimit: 0,
+    });
+
+    expect(result.some((card) => card.id === targetCardId)).toBe(true);
+    expect(result.some((card) => card.id === otherCardId)).toBe(false);
+    expect(result.some((card) => card.id === unlinkedCardId)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- prioritize card-first session composition using overdue structural knowledge components
- keep kcId targeting explicit on `/session/targeted` and cover it with tests
- add focused regression coverage for KC-driven due-session selection

## Verification
- bun run --filter @rzyns/strus-db test
- bun run --filter @rzyns/strus-db typecheck
- bun run --filter @rzyns/strus-api test
- bun run --filter @rzyns/strus-api typecheck