### PR TITLE
STR-22: add phase 2 KC dashboard FSRS state

### DIFF
--- a/packages/api/src/analytics-kc-mastery.test.ts
+++ b/packages/api/src/analytics-kc-mastery.test.ts
@@ -4,7 +4,7 @@
  * Tests for STR-17 (KC4): Analytics API endpoints that aggregate FSRS stability
  * per knowledge component via the card_knowledge_components junction table.
  */
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll, beforeEach } from "bun:test";
 import { resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
@@ -15,6 +15,9 @@ import {
   cardKnowledgeComponents,
   cards,
   notes,
+  reviews,
+  vocabListNotes,
+  vocabLists,
   createInitialKnowledgeComponentFsrsState,
 } from "@rzyns/strus-db";
 import { router } from "./router.js";
@@ -36,6 +39,18 @@ const PAST = NOW_SECS - 3600;       // 1 hour ago — overdue
 const FUTURE = NOW_SECS + 86400;    // tomorrow — not due
 const KC_FUTURE = NOW_SECS + 10 * 86400; // comfortably scheduled KC
 const KC_SOON = NOW_SECS + 2 * 86400;    // upcoming KC due soon
+
+beforeEach(() => {
+  // Root `bun test` shares one in-memory DB across files, so these analytics
+  // assertions must start from a clean slate instead of inheriting seeded KCs.
+  db.delete(reviews).run();
+  db.delete(cardKnowledgeComponents).run();
+  db.delete(vocabListNotes).run();
+  db.delete(cards).run();
+  db.delete(knowledgeComponents).run();
+  db.delete(notes).run();
+  db.delete(vocabLists).run();
+});
 
 function makeKC(opts: {
   kind?: "case" | "number" | "tense" | "mood" | "gender" | "pos" | "lemma";

--- a/packages/api/src/analytics-kc-mastery.test.ts
+++ b/packages/api/src/analytics-kc-mastery.test.ts
@@ -34,11 +34,19 @@ const NOW = new Date();
 const NOW_SECS = Math.floor(Date.now() / 1000);
 const PAST = NOW_SECS - 3600;       // 1 hour ago — overdue
 const FUTURE = NOW_SECS + 86400;    // tomorrow — not due
+const KC_FUTURE = NOW_SECS + 10 * 86400; // comfortably scheduled KC
+const KC_SOON = NOW_SECS + 2 * 86400;    // upcoming KC due soon
 
 function makeKC(opts: {
   kind?: "case" | "number" | "tense" | "mood" | "gender" | "pos" | "lemma";
   label: string;
   labelPl?: string;
+  kcDue?: number;
+  kcStability?: number;
+  scheduledDays?: number;
+  reps?: number;
+  lapses?: number;
+  lastReview?: number | null;
 }): string {
   const id = randomUUID();
   const fsrs = createInitialKnowledgeComponentFsrsState();
@@ -50,6 +58,12 @@ function makeKC(opts: {
     tagPattern: "*:gen:*",
     lemmaId: null,
     ...fsrs,
+    due: opts.kcDue ?? KC_FUTURE,
+    stability: opts.kcStability ?? 14,
+    scheduledDays: opts.scheduledDays ?? 7,
+    reps: opts.reps ?? fsrs.reps,
+    lapses: opts.lapses ?? fsrs.lapses,
+    lastReview: opts.lastReview ?? fsrs.lastReview,
     createdAt: NOW,
   }).run();
   return id;
@@ -134,6 +148,34 @@ describe("analytics.kcMastery", () => {
     expect(kc!.masteredCount).toBe(1);
     expect(kc!.avgStability).toBeCloseTo((5 + 30) / 2, 5);
     expect(kc!.masteredPct).toBe(50.0);
+  });
+
+  test("includes current KC scheduler fields for due-state UI", async () => {
+    const kcId = makeKC({
+      kind: "case",
+      label: "current-kc-status",
+      kcDue: PAST,
+      kcStability: 4.5,
+      scheduledDays: 2,
+      reps: 6,
+      lapses: 1,
+      lastReview: PAST - 7200,
+    });
+    const card = makeCard({ stability: 12, due: FUTURE });
+
+    linkCardToKC(card, kcId);
+
+    const result = await call(router.analytics.kcMastery, { kind: "case", limit: 200, sort: "weakest" });
+    const kc = result.find((r) => r.id === kcId);
+
+    expect(kc).toBeDefined();
+    expect(kc!.dueStatus).toBe("overdue");
+    expect(kc!.currentStability).toBeCloseTo(4.5, 5);
+    expect(kc!.scheduledDays).toBe(2);
+    expect(kc!.reps).toBe(6);
+    expect(kc!.lapses).toBe(1);
+    expect(kc!.currentDue).toContain("T");
+    expect(kc!.lastReview).toContain("T");
   });
 
   test("KC with zero linked cards: masteredPct=0, avgStability=0", async () => {
@@ -258,5 +300,36 @@ describe("analytics.kcSummary", () => {
     const result = await call(router.analytics.kcSummary, {});
     // At least 1 overdue card from our setup
     expect(result.totalDueCards).toBeGreaterThanOrEqual(1);
+  });
+
+  test("structuralDueStates bucket current KC scheduler state", async () => {
+    const overdueId = makeKC({ kind: "case", label: "summary-overdue", kcDue: PAST, kcStability: 5 });
+    const upcomingId = makeKC({ kind: "case", label: "summary-upcoming", kcDue: KC_SOON, kcStability: 8 });
+    const scheduledId = makeKC({ kind: "case", label: "summary-scheduled", kcDue: KC_FUTURE, kcStability: 20 });
+
+    linkCardToKC(makeCard({ stability: 11, due: FUTURE }), overdueId);
+    linkCardToKC(makeCard({ stability: 11, due: FUTURE }), upcomingId);
+    linkCardToKC(makeCard({ stability: 11, due: FUTURE }), scheduledId);
+
+    const result = await call(router.analytics.kcSummary, {});
+    expect(result.structuralDueStates.overdue).toBeGreaterThanOrEqual(1);
+    expect(result.structuralDueStates.upcoming).toBeGreaterThanOrEqual(1);
+    expect(result.structuralDueStates.scheduled).toBeGreaterThanOrEqual(1);
+  });
+
+  test("weakestKC prefers the weakest populated overdue structural KC", async () => {
+    const weakestId = makeKC({ kind: "case", label: "summary-weakest-overdue", kcDue: PAST, kcStability: 1.5 });
+    const strongerOverdueId = makeKC({ kind: "case", label: "summary-stronger-overdue", kcDue: PAST, kcStability: 6 });
+    const scheduledButLowerAvgId = makeKC({ kind: "case", label: "summary-scheduled-low-avg", kcDue: KC_FUTURE, kcStability: 0.5 });
+
+    linkCardToKC(makeCard({ stability: 9, due: FUTURE }), weakestId);
+    linkCardToKC(makeCard({ stability: 15, due: FUTURE }), strongerOverdueId);
+    linkCardToKC(makeCard({ stability: 2, due: FUTURE }), scheduledButLowerAvgId);
+
+    const result = await call(router.analytics.kcSummary, {});
+    expect(result.weakestKC?.id).toBe(weakestId);
+    expect(result.weakestKC?.dueStatus).toBe("overdue");
+    expect(result.weakestKC?.currentStability).toBeCloseTo(1.5, 5);
+    expect(result.weakestKC?.currentDue).toContain("T");
   });
 });

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -3997,19 +3997,174 @@ const analyticsWeakConcepts = os
 /** FSRS stability threshold in days for a card to be considered "mastered". */
 const MASTERY_THRESHOLD = 21;
 
+const KC_KINDS = ["case", "number", "tense", "mood", "gender", "pos", "lemma"] as const;
+const KC_DUE_STATUS_VALUES = ["overdue", "upcoming", "scheduled"] as const;
+const KC_UPCOMING_WINDOW_SECS = 3 * 24 * 60 * 60;
+
+type KcDueStatus = (typeof KC_DUE_STATUS_VALUES)[number];
+
+function classifyKcDueStatus(due: number, nowSecs: number): KcDueStatus {
+  if (due <= nowSecs) return "overdue";
+  if (due <= nowSecs + KC_UPCOMING_WINDOW_SECS) return "upcoming";
+  return "scheduled";
+}
+
+const KcDueStatusOutput = z.enum(KC_DUE_STATUS_VALUES).describe(
+  "Current KC scheduler status: overdue = due now/past due, upcoming = due within 3 days, scheduled = comfortably scheduled later",
+);
+
+type AggregatedKcRow = {
+  id: string;
+  kind: string;
+  label: string;
+  labelPl: string | null;
+  currentState: number;
+  currentDue: string;
+  currentStability: number;
+  scheduledDays: number;
+  reps: number;
+  lapses: number;
+  lastReview: string | null;
+  dueStatus: KcDueStatus;
+  avgStability: number;
+  totalCards: number;
+  overdueCount: number;
+  masteredCount: number;
+  masteredPct: number;
+};
+
+function loadAggregatedKcs(inputKind?: (typeof KC_KINDS)[number]): {
+  rows: AggregatedKcRow[];
+  dueCardIds: Set<string>;
+} {
+  const nowSecs = Math.floor(Date.now() / 1000);
+
+  const rawRows = db
+    .select({
+      kcId: knowledgeComponents.id,
+      kind: knowledgeComponents.kind,
+      label: knowledgeComponents.label,
+      labelPl: knowledgeComponents.labelPl,
+      currentState: knowledgeComponents.state,
+      currentDue: knowledgeComponents.due,
+      currentStability: knowledgeComponents.stability,
+      scheduledDays: knowledgeComponents.scheduledDays,
+      reps: knowledgeComponents.reps,
+      lapses: knowledgeComponents.lapses,
+      lastReview: knowledgeComponents.lastReview,
+      cardId: cards.id,
+      cardStability: cards.stability,
+      cardDue: cards.due,
+    })
+    .from(knowledgeComponents)
+    .leftJoin(cardKnowledgeComponents, eq(cardKnowledgeComponents.kcId, knowledgeComponents.id))
+    .leftJoin(cards, eq(cards.id, cardKnowledgeComponents.cardId))
+    .where(inputKind ? eq(knowledgeComponents.kind, inputKind) : undefined)
+    .all();
+
+  if (rawRows.length === 0) {
+    return { rows: [], dueCardIds: new Set<string>() };
+  }
+
+  const dueCardIds = new Set<string>();
+  const kcMap = new Map<string, {
+    kind: string;
+    label: string;
+    labelPl: string | null;
+    currentState: number;
+    currentDue: number;
+    currentStability: number;
+    scheduledDays: number;
+    reps: number;
+    lapses: number;
+    lastReview: number | null;
+    stabilitySum: number;
+    totalCards: number;
+    overdueCount: number;
+    masteredCount: number;
+  }>();
+
+  for (const row of rawRows) {
+    const existing = kcMap.get(row.kcId);
+    const hasCard = row.cardId !== null && row.cardStability !== null && row.cardDue !== null;
+
+    if (hasCard && row.cardDue! <= nowSecs) {
+      dueCardIds.add(row.cardId!);
+    }
+
+    if (existing) {
+      if (hasCard) {
+        existing.stabilitySum += row.cardStability!;
+        existing.totalCards += 1;
+        if (row.cardDue! <= nowSecs) existing.overdueCount += 1;
+        if (row.cardStability! > MASTERY_THRESHOLD) existing.masteredCount += 1;
+      }
+      continue;
+    }
+
+    kcMap.set(row.kcId, {
+      kind: row.kind,
+      label: row.label,
+      labelPl: row.labelPl,
+      currentState: row.currentState,
+      currentDue: row.currentDue,
+      currentStability: row.currentStability,
+      scheduledDays: row.scheduledDays,
+      reps: row.reps,
+      lapses: row.lapses,
+      lastReview: row.lastReview,
+      stabilitySum: hasCard ? row.cardStability! : 0,
+      totalCards: hasCard ? 1 : 0,
+      overdueCount: hasCard && row.cardDue! <= nowSecs ? 1 : 0,
+      masteredCount: hasCard && row.cardStability! > MASTERY_THRESHOLD ? 1 : 0,
+    });
+  }
+
+  return {
+    dueCardIds,
+    rows: [...kcMap.entries()].map(([id, data]) => ({
+      id,
+      kind: data.kind,
+      label: data.label,
+      labelPl: data.labelPl,
+      currentState: data.currentState,
+      currentDue: new Date(data.currentDue * 1000).toISOString(),
+      currentStability: data.currentStability,
+      scheduledDays: data.scheduledDays,
+      reps: data.reps,
+      lapses: data.lapses,
+      lastReview: data.lastReview != null ? new Date(data.lastReview * 1000).toISOString() : null,
+      dueStatus: classifyKcDueStatus(data.currentDue, nowSecs),
+      avgStability: data.totalCards > 0 ? data.stabilitySum / data.totalCards : 0,
+      totalCards: data.totalCards,
+      overdueCount: data.overdueCount,
+      masteredCount: data.masteredCount,
+      masteredPct: data.totalCards > 0
+        ? Math.round((data.masteredCount / data.totalCards) * 1000) / 10
+        : 0,
+    })),
+  };
+}
+
 const KcMasteryOutput = z.object({
   id: z.string().describe("Knowledge component ID"),
   kind: z.string().describe("KC kind: 'case' | 'number' | 'tense' | 'mood' | 'gender' | 'pos' | 'lemma'"),
   label: z.string().describe("English label, e.g. 'genitive'"),
   labelPl: z.string().nullable().describe("Polish label, e.g. 'dopełniacz'"),
+  currentState: z.number().int().describe("Current KC-level FSRS state stored on knowledge_components"),
+  currentDue: zIso.describe("When this KC is next due according to the KC scheduler"),
+  currentStability: z.number().describe("Current KC-level FSRS stability in days"),
+  scheduledDays: z.number().int().describe("Current KC-level scheduled interval in days"),
+  reps: z.number().int().describe("Total KC-level review count"),
+  lapses: z.number().int().describe("Total KC-level forget count"),
+  lastReview: zIso.nullable().describe("Most recent KC-level review timestamp; null if never reviewed"),
+  dueStatus: KcDueStatusOutput,
   avgStability: z.number().describe("Average FSRS stability across linked cards"),
   totalCards: z.number().int().describe("Total cards linked to this KC"),
   overdueCount: z.number().int().describe("Cards past their due date"),
   masteredCount: z.number().int().describe("Cards with stability > MASTERY_THRESHOLD"),
   masteredPct: z.number().describe("masteredCount / totalCards * 100, rounded to 1 decimal; 0 when totalCards=0"),
 });
-
-const KC_KINDS = ["case", "number", "tense", "mood", "gender", "pos", "lemma"] as const;
 
 const analyticsKcMastery = os
   .route({
@@ -4032,81 +4187,23 @@ const analyticsKcMastery = os
   }))
   .output(z.array(KcMasteryOutput))
   .handler(async ({ input }) => {
-    const nowSecs = Math.floor(Date.now() / 1000);
-
-    // Fetch all KCs with their linked card data (left join so zero-card KCs appear)
-    const rows = db
-      .select({
-        kcId: knowledgeComponents.id,
-        kind: knowledgeComponents.kind,
-        label: knowledgeComponents.label,
-        labelPl: knowledgeComponents.labelPl,
-        stability: cards.stability,
-        due: cards.due,
-      })
-      .from(knowledgeComponents)
-      .leftJoin(cardKnowledgeComponents, eq(cardKnowledgeComponents.kcId, knowledgeComponents.id))
-      .leftJoin(cards, eq(cards.id, cardKnowledgeComponents.cardId))
-      .where(input.kind ? eq(knowledgeComponents.kind, input.kind) : undefined)
-      .all();
-
+    const { rows } = loadAggregatedKcs(input.kind);
     if (rows.length === 0) return [];
 
-    // Group in memory by KC id
-    const kcMap = new Map<string, {
-      kind: string;
-      label: string;
-      labelPl: string | null;
-      stabilitySum: number;
-      totalCards: number;
-      overdueCount: number;
-      masteredCount: number;
-    }>();
+    const result = [...rows];
 
-    for (const row of rows) {
-      const existing = kcMap.get(row.kcId);
-      if (existing) {
-        if (row.stability !== null && row.due !== null) {
-          existing.stabilitySum += row.stability;
-          existing.totalCards += 1;
-          if (row.due <= nowSecs) existing.overdueCount += 1;
-          if (row.stability > MASTERY_THRESHOLD) existing.masteredCount += 1;
-        }
-      } else {
-        const hasCard = row.stability !== null && row.due !== null;
-        kcMap.set(row.kcId, {
-          kind: row.kind,
-          label: row.label,
-          labelPl: row.labelPl,
-          stabilitySum: hasCard ? row.stability! : 0,
-          totalCards: hasCard ? 1 : 0,
-          overdueCount: hasCard && row.due! <= nowSecs ? 1 : 0,
-          masteredCount: hasCard && row.stability! > MASTERY_THRESHOLD ? 1 : 0,
-        });
-      }
-    }
-
-    // Build result array
-    const result = [...kcMap.entries()]
-      .map(([id, data]) => ({
-        id,
-        kind: data.kind,
-        label: data.label,
-        labelPl: data.labelPl,
-        avgStability: data.totalCards > 0 ? data.stabilitySum / data.totalCards : 0,
-        totalCards: data.totalCards,
-        overdueCount: data.overdueCount,
-        masteredCount: data.masteredCount,
-        masteredPct: data.totalCards > 0
-          ? Math.round((data.masteredCount / data.totalCards) * 1000) / 10
-          : 0,
-      }));
-
-    // Sort
     if (input.sort === "weakest") {
-      result.sort((a, b) => a.avgStability - b.avgStability);
+      result.sort((a, b) => {
+        const aEmpty = a.totalCards === 0 ? 1 : 0;
+        const bEmpty = b.totalCards === 0 ? 1 : 0;
+        return aEmpty - bEmpty || a.avgStability - b.avgStability || a.label.localeCompare(b.label);
+      });
     } else if (input.sort === "strongest") {
-      result.sort((a, b) => b.avgStability - a.avgStability);
+      result.sort((a, b) => {
+        const aEmpty = a.totalCards === 0 ? 1 : 0;
+        const bEmpty = b.totalCards === 0 ? 1 : 0;
+        return aEmpty - bEmpty || b.avgStability - a.avgStability || a.label.localeCompare(b.label);
+      });
     } else {
       result.sort((a, b) => a.label.localeCompare(b.label));
     }
@@ -4118,12 +4215,20 @@ const KcSummaryOutput = z.object({
   totalLemmas: z.number().int().describe("Count of kind='lemma' KCs"),
   masteredLemmas: z.number().int().describe("Lemma KCs where masteredPct >= 80"),
   totalStructural: z.number().int().describe("Count of non-lemma KCs"),
+  structuralDueStates: z.object({
+    overdue: z.number().int().describe("Structural KCs with linked cards whose KC scheduler says they are overdue"),
+    upcoming: z.number().int().describe("Structural KCs with linked cards due within the next 3 days"),
+    scheduled: z.number().int().describe("Structural KCs with linked cards scheduled beyond the next 3 days"),
+  }),
   weakestKC: z.object({
     id: z.string(),
     label: z.string(),
     labelPl: z.string().nullable(),
     kind: z.string(),
     avgStability: z.number(),
+    currentDue: zIso,
+    currentStability: z.number(),
+    dueStatus: KcDueStatusOutput,
   }).nullable().describe("Structural KC with lowest average stability (null if none)"),
   totalDueCards: z.number().int().describe("Cards past due across all linked KCs"),
 });
@@ -4137,88 +4242,70 @@ const analyticsKcSummary = os
     description:
       "Returns aggregate counts for the dashboard overview. " +
       "totalDueCards counts distinct overdue cards across all KCs. " +
-      "weakestKC is the non-lemma KC with the lowest average stability.",
+      "weakestKC is the non-lemma KC with the weakest current scheduler state among populated KCs.",
   })
   .input(z.object({}))
   .output(KcSummaryOutput)
   .handler(async () => {
-    const nowSecs = Math.floor(Date.now() / 1000);
-
-    // Fetch all KCs with card data
-    const rows = db
-      .select({
-        kcId: knowledgeComponents.id,
-        kind: knowledgeComponents.kind,
-        label: knowledgeComponents.label,
-        labelPl: knowledgeComponents.labelPl,
-        cardId: cards.id,
-        stability: cards.stability,
-        due: cards.due,
-      })
-      .from(knowledgeComponents)
-      .leftJoin(cardKnowledgeComponents, eq(cardKnowledgeComponents.kcId, knowledgeComponents.id))
-      .leftJoin(cards, eq(cards.id, cardKnowledgeComponents.cardId))
-      .all();
+    const { rows, dueCardIds } = loadAggregatedKcs();
 
     if (rows.length === 0) {
-      return { totalLemmas: 0, masteredLemmas: 0, totalStructural: 0, weakestKC: null, totalDueCards: 0 };
-    }
-
-    // Group by KC
-    const kcMap = new Map<string, {
-      kind: string;
-      label: string;
-      labelPl: string | null;
-      stabilitySum: number;
-      totalCards: number;
-      masteredCount: number;
-    }>();
-    const dueCardIds = new Set<string>();
-
-    for (const row of rows) {
-      const existing = kcMap.get(row.kcId);
-      if (existing) {
-        if (row.stability !== null && row.due !== null && row.cardId !== null) {
-          existing.stabilitySum += row.stability;
-          existing.totalCards += 1;
-          if (row.stability > MASTERY_THRESHOLD) existing.masteredCount += 1;
-          if (row.due <= nowSecs) dueCardIds.add(row.cardId);
-        }
-      } else {
-        const hasCard = row.stability !== null && row.due !== null && row.cardId !== null;
-        kcMap.set(row.kcId, {
-          kind: row.kind,
-          label: row.label,
-          labelPl: row.labelPl,
-          stabilitySum: hasCard ? row.stability! : 0,
-          totalCards: hasCard ? 1 : 0,
-          masteredCount: hasCard && row.stability! > MASTERY_THRESHOLD ? 1 : 0,
-        });
-        if (hasCard && row.due! <= nowSecs) dueCardIds.add(row.cardId!);
-      }
+      return {
+        totalLemmas: 0,
+        masteredLemmas: 0,
+        totalStructural: 0,
+        structuralDueStates: { overdue: 0, upcoming: 0, scheduled: 0 },
+        weakestKC: null,
+        totalDueCards: 0,
+      };
     }
 
     let totalLemmas = 0;
     let masteredLemmas = 0;
     let totalStructural = 0;
-    let weakestKC: { id: string; label: string; labelPl: string | null; kind: string; avgStability: number } | null = null;
+    const structuralDueStates = { overdue: 0, upcoming: 0, scheduled: 0 };
+    let weakestKC: {
+      id: string;
+      label: string;
+      labelPl: string | null;
+      kind: string;
+      avgStability: number;
+      currentDue: string;
+      currentStability: number;
+      dueStatus: KcDueStatus;
+    } | null = null;
 
-    for (const [kcId, data] of kcMap.entries()) {
-      const avgStability = data.totalCards > 0 ? data.stabilitySum / data.totalCards : 0;
-      const masteredPct = data.totalCards > 0
-        ? Math.round((data.masteredCount / data.totalCards) * 1000) / 10
-        : 0;
+    const weakestStatusRank = (status: KcDueStatus) =>
+      status === "overdue" ? 0 : status === "upcoming" ? 1 : 2;
 
-      if (data.kind === "lemma") {
+    for (const row of rows) {
+      if (row.kind === "lemma") {
         totalLemmas += 1;
-        if (masteredPct >= 80) masteredLemmas += 1;
-      } else {
-        totalStructural += 1;
-        if (data.totalCards > 0) {
-          if (weakestKC === null || avgStability < weakestKC.avgStability) {
-            weakestKC = { id: kcId, label: data.label, labelPl: data.labelPl, kind: data.kind, avgStability };
-          }
-        }
+        if (row.masteredPct >= 80) masteredLemmas += 1;
+        continue;
+      }
+
+      totalStructural += 1;
+      if (row.totalCards === 0) continue;
+
+      structuralDueStates[row.dueStatus] += 1;
+
+      if (
+        weakestKC === null ||
+        weakestStatusRank(row.dueStatus) < weakestStatusRank(weakestKC.dueStatus) ||
+        (row.dueStatus === weakestKC.dueStatus && row.currentStability < weakestKC.currentStability) ||
+        (row.dueStatus === weakestKC.dueStatus && row.currentStability === weakestKC.currentStability && row.avgStability < weakestKC.avgStability)
+      ) {
+        weakestKC = {
+          id: row.id,
+          label: row.label,
+          labelPl: row.labelPl,
+          kind: row.kind,
+          avgStability: row.avgStability,
+          currentDue: row.currentDue,
+          currentStability: row.currentStability,
+          dueStatus: row.dueStatus,
+        };
       }
     }
 
@@ -4226,6 +4313,7 @@ const analyticsKcSummary = os
       totalLemmas,
       masteredLemmas,
       totalStructural,
+      structuralDueStates,
       weakestKC,
       totalDueCards: dueCardIds.size,
     };

--- a/packages/web/src/components/KcDashboard.tsx
+++ b/packages/web/src/components/KcDashboard.tsx
@@ -5,13 +5,22 @@ import { api } from '../api/client'
 import { Card } from './Card'
 import { Spinner } from './Spinner'
 import { ErrorState } from './ErrorState'
-import { MasteryBar } from './MasteryBar'
+
+type KcDueStatus = 'overdue' | 'upcoming' | 'scheduled'
 
 type KcItem = {
   id: string
   kind: string
   label: string
   labelPl: string | null
+  currentState: number
+  currentDue: string
+  currentStability: number
+  scheduledDays: number
+  reps: number
+  lapses: number
+  lastReview: string | null
+  dueStatus: KcDueStatus
   avgStability: number
   totalCards: number
   overdueCount: number
@@ -19,7 +28,19 @@ type KcItem = {
   masteredPct: number
 }
 
-// Dimension kinds to show in the "other dimensions" section
+type KcSummary = {
+  totalLemmas: number
+  masteredLemmas: number
+  totalStructural: number
+  totalDueCards: number
+  structuralDueStates: {
+    overdue: number
+    upcoming: number
+    scheduled: number
+  }
+  weakestKC: Pick<KcItem, 'id' | 'kind' | 'label' | 'labelPl' | 'avgStability' | 'currentDue' | 'currentStability' | 'dueStatus'> | null
+}
+
 const DIMENSION_KINDS = [
   { kind: 'number', label: 'Numbers' },
   { kind: 'gender', label: 'Genders' },
@@ -27,6 +48,58 @@ const DIMENSION_KINDS = [
   { kind: 'mood', label: 'Moods' },
   { kind: 'pos', label: 'Parts of Speech' },
 ] as const
+
+function buildFocusedSessionHref(kc: { id: string; label: string; labelPl: string | null }) {
+  const params = new URLSearchParams({ kcId: kc.id })
+  if (kc.label) params.set('kcLabel', kc.label)
+  if (kc.labelPl) params.set('kcLabelPl', kc.labelPl)
+  return `/quiz?${params.toString()}`
+}
+
+function masteryColor(pct: number): string {
+  if (pct >= 80) return 'green.9'
+  if (pct >= 40) return 'yellow.9'
+  return 'red.9'
+}
+
+function formatStability(stability: number): string {
+  if (stability <= 0.1) return 'new'
+  if (stability < 10) return `${stability.toFixed(1)}d`
+  return `${Math.round(stability)}d`
+}
+
+function formatDueHint(dueIso: string, status: KcDueStatus): string {
+  const diffMs = new Date(dueIso).getTime() - Date.now()
+  const absMs = Math.abs(diffMs)
+  const absHours = Math.max(1, Math.round(absMs / (1000 * 60 * 60)))
+  const absDays = Math.max(1, Math.round(absMs / (1000 * 60 * 60 * 24)))
+
+  if (status === 'overdue') {
+    return absHours < 24 ? `${absHours}h late` : `${absDays}d late`
+  }
+
+  if (status === 'upcoming') {
+    if (diffMs <= 24 * 60 * 60 * 1000) return 'due today'
+    if (diffMs <= 48 * 60 * 60 * 1000) return 'due tomorrow'
+    return `in ${absDays}d`
+  }
+
+  if (diffMs <= 7 * 24 * 60 * 60 * 1000) {
+    return `in ${absDays}d`
+  }
+
+  return new Date(dueIso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function dueStateTokens(status: KcDueStatus) {
+  if (status === 'overdue') {
+    return { label: 'Overdue', bg: 'red.2', border: 'red.6', fg: 'red.11' }
+  }
+  if (status === 'upcoming') {
+    return { label: 'Due soon', bg: 'amber.2', border: 'amber.6', fg: 'amber.11' }
+  }
+  return { label: 'Comfortable', bg: 'green.2', border: 'green.6', fg: 'green.11' }
+}
 
 function ProgressRing(props: { value: number; max: number; size?: number }) {
   const size = () => props.size ?? 80
@@ -71,8 +144,215 @@ function ProgressRing(props: { value: number; max: number; size?: number }) {
   )
 }
 
+function DueStateBadge(props: { status: KcDueStatus; dueIso: string }) {
+  const tokens = () => dueStateTokens(props.status)
+
+  return (
+    <span
+      class={css({
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '1.5',
+        px: '2',
+        py: '0.5',
+        borderRadius: 'full',
+        border: '1px solid',
+        fontSize: 'xs',
+        fontWeight: 'medium',
+        whiteSpace: 'nowrap',
+      })}
+      style={{
+        'background-color': `var(--colors-${tokens().bg.replace('.', '-')})`,
+        'border-color': `var(--colors-${tokens().border.replace('.', '-')})`,
+        color: `var(--colors-${tokens().fg.replace('.', '-')})`,
+      }}
+      title={new Date(props.dueIso).toLocaleString()}
+    >
+      <span>{tokens().label}</span>
+      <span class={css({ opacity: 0.85 })}>{formatDueHint(props.dueIso, props.status)}</span>
+    </span>
+  )
+}
+
+function SummaryCountBadge(props: { count: number; label: string; tone: KcDueStatus }) {
+  const tokens = () => dueStateTokens(props.tone)
+
+  return (
+    <span
+      class={css({
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '1.5',
+        px: '2.5',
+        py: '1',
+        borderRadius: 'full',
+        border: '1px solid',
+        fontSize: 'xs',
+        fontWeight: 'medium',
+      })}
+      style={{
+        'background-color': `var(--colors-${tokens().bg.replace('.', '-')})`,
+        'border-color': `var(--colors-${tokens().border.replace('.', '-')})`,
+        color: `var(--colors-${tokens().fg.replace('.', '-')})`,
+      }}
+    >
+      <span>{props.count}</span>
+      <span>{props.label}</span>
+    </span>
+  )
+}
+
+function KcLabel(props: { kc: Pick<KcItem, 'label' | 'labelPl'> }) {
+  return (
+    <>
+      <span class={css({ fontSize: 'sm', fontWeight: 'semibold', color: 'fg.default' })}>
+        {props.kc.labelPl ?? props.kc.label}
+      </span>
+      <Show when={props.kc.labelPl}>
+        <span class={css({ fontSize: 'xs', color: 'fg.muted' })}>({props.kc.label})</span>
+      </Show>
+    </>
+  )
+}
+
+function KcRow(props: { kc: KcItem }) {
+  const pct = () => Math.min(100, Math.max(0, props.kc.masteredPct))
+  const canPractice = () => props.kc.totalCards > 0
+
+  return (
+    <div class={css({
+      p: '3',
+      border: '1px solid',
+      borderColor: 'border',
+      borderRadius: 'l2',
+      bg: 'bg',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2',
+    })}>
+      <div class={css({ display: 'flex', justifyContent: 'space-between', gap: '3', alignItems: 'flex-start', flexWrap: 'wrap' })}>
+        <div class={css({ display: 'flex', flexDirection: 'column', gap: '0.5' })}>
+          <div class={css({ display: 'flex', alignItems: 'center', gap: '2', flexWrap: 'wrap' })}>
+            <KcLabel kc={props.kc} />
+          </div>
+          <div class={css({ display: 'flex', alignItems: 'center', gap: '2', flexWrap: 'wrap' })}>
+            <DueStateBadge status={props.kc.dueStatus} dueIso={props.kc.currentDue} />
+          </div>
+        </div>
+
+        <Show when={canPractice()}>
+          <A
+            href={buildFocusedSessionHref(props.kc)}
+            class={css({
+              fontSize: 'xs',
+              fontWeight: 'semibold',
+              color: 'blue.11',
+              textDecoration: 'none',
+              px: '2.5',
+              py: '1',
+              borderRadius: 'full',
+              bg: 'blue.2',
+              border: '1px solid',
+              borderColor: 'blue.6',
+              _hover: { bg: 'blue.3' },
+            })}
+          >
+            Practice →
+          </A>
+        </Show>
+      </div>
+
+      <div class={css({ display: 'flex', alignItems: 'center', gap: '3' })}>
+        <div class={css({ flex: 1, position: 'relative', height: '2.5', bg: 'bg.subtle', borderRadius: 'full', overflow: 'hidden' })}>
+          <div
+            class={css({ position: 'absolute', inset: 0, borderRadius: 'full', transition: 'width 0.3s ease' })}
+            style={{
+              width: `${pct()}%`,
+              'background-color': `var(--colors-${masteryColor(props.kc.masteredPct).replace('.', '-')})`,
+            }}
+          />
+        </div>
+        <span
+          class={css({ minWidth: '12', textAlign: 'right', fontSize: 'sm', fontWeight: 'semibold' })}
+          style={{ color: `var(--colors-${masteryColor(props.kc.masteredPct).replace('.', '-')})` }}
+        >
+          {props.kc.masteredPct}%
+        </span>
+      </div>
+
+      <div class={css({ display: 'flex', flexWrap: 'wrap', gap: '2', fontSize: 'xs', color: 'fg.muted' })}>
+        <span>KC stability {formatStability(props.kc.currentStability)}</span>
+        <span>{props.kc.totalCards} {props.kc.totalCards === 1 ? 'card' : 'cards'}</span>
+        <Show when={props.kc.overdueCount > 0}>
+          <span>{props.kc.overdueCount} overdue {props.kc.overdueCount === 1 ? 'card' : 'cards'}</span>
+        </Show>
+        <Show when={props.kc.reps > 0}>
+          <span>{props.kc.reps} reviews</span>
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+function LemmaKcCard(props: { kc: KcItem }) {
+  return (
+    <div class={css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2.5',
+      p: '3',
+      border: '1px solid',
+      borderColor: 'border',
+      borderRadius: 'l2',
+      bg: 'bg',
+    })}>
+      <div class={css({ display: 'flex', justifyContent: 'space-between', gap: '2', alignItems: 'flex-start' })}>
+        <div class={css({ minWidth: 0, display: 'flex', flexDirection: 'column', gap: '1' })}>
+          <span class={css({ fontSize: 'sm', fontWeight: 'semibold', color: 'fg.default', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
+            {props.kc.labelPl ?? props.kc.label}
+          </span>
+          <DueStateBadge status={props.kc.dueStatus} dueIso={props.kc.currentDue} />
+        </div>
+        <span
+          class={css({ fontSize: 'sm', fontWeight: 'semibold', flexShrink: 0 })}
+          style={{ color: `var(--colors-${masteryColor(props.kc.masteredPct).replace('.', '-')})` }}
+        >
+          {props.kc.masteredPct}%
+        </span>
+      </div>
+
+      <div class={css({ fontSize: 'xs', color: 'fg.muted', display: 'flex', flexDirection: 'column', gap: '1' })}>
+        <span>KC stability {formatStability(props.kc.currentStability)}</span>
+        <span>{props.kc.totalCards} {props.kc.totalCards === 1 ? 'card' : 'cards'}</span>
+      </div>
+
+      <Show when={props.kc.totalCards > 0}>
+        <A
+          href={buildFocusedSessionHref(props.kc)}
+          class={css({
+            display: 'inline-flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            px: '3',
+            py: '1.5',
+            borderRadius: 'l2',
+            bg: 'blue.9',
+            color: 'white',
+            fontSize: 'xs',
+            fontWeight: 'semibold',
+            textDecoration: 'none',
+            _hover: { bg: 'blue.10' },
+          })}
+        >
+          Practice lemma KC
+        </A>
+      </Show>
+    </div>
+  )
+}
+
 function SummaryBar() {
-  const [summary, { refetch }] = createResource(() => api.analytics.kcSummary({}))
+  const [summary, { refetch }] = createResource(() => api.analytics.kcSummary({}) as Promise<KcSummary>)
 
   return (
     <ErrorBoundary fallback={(err) => <ErrorState message={String(err)} onRetry={refetch} />}>
@@ -97,10 +377,10 @@ function SummaryBar() {
         >
           {(() => {
             const data = () => summary()!
+            const weakest = () => data().weakestKC
             return (
               <Card>
                 <div class={css({ display: 'flex', alignItems: 'center', gap: '6', flexWrap: 'wrap' })}>
-                  {/* Progress ring */}
                   <div class={css({ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1' })}>
                     <ProgressRing value={data().masteredLemmas} max={data().totalLemmas} size={80} />
                     <span class={css({ fontSize: 'xs', color: 'fg.muted', textAlign: 'center' })}>
@@ -108,50 +388,53 @@ function SummaryBar() {
                     </span>
                   </div>
 
-                  {/* Main stats */}
-                  <div class={css({ flex: 1 })}>
-                    <h2 class={css({ fontSize: 'xl', fontWeight: 'bold', color: 'fg.default', mb: '1' })}>
-                      {data().masteredLemmas} / {data().totalLemmas} lemmas mastered
-                    </h2>
-                    <p class={css({ fontSize: 'sm', color: 'fg.muted', mb: '2' })}>
-                      {data().totalDueCards} cards due
-                    </p>
-                    <Show when={data().weakestKC}>
+                  <div class={css({ flex: 1, minWidth: '18rem', display: 'flex', flexDirection: 'column', gap: '2' })}>
+                    <div>
+                      <h2 class={css({ fontSize: 'xl', fontWeight: 'bold', color: 'fg.default', mb: '1' })}>
+                        {data().masteredLemmas} / {data().totalLemmas} lemmas mastered
+                      </h2>
+                      <p class={css({ fontSize: 'sm', color: 'fg.muted' })}>
+                        {data().totalDueCards} cards due across {data().totalStructural} structural KCs
+                      </p>
+                    </div>
+
+                    <div class={css({ display: 'flex', gap: '2', flexWrap: 'wrap' })}>
+                      <SummaryCountBadge count={data().structuralDueStates.overdue} label="overdue KCs" tone="overdue" />
+                      <SummaryCountBadge count={data().structuralDueStates.upcoming} label="due soon" tone="upcoming" />
+                      <SummaryCountBadge count={data().structuralDueStates.scheduled} label="comfortable" tone="scheduled" />
+                    </div>
+
+                    <Show when={weakest()}>
                       {(kc) => (
                         <div class={css({
                           display: 'inline-flex',
+                          flexWrap: 'wrap',
                           alignItems: 'center',
                           gap: '2',
                           px: '3',
-                          py: '1.5',
+                          py: '2',
                           bg: 'orange.2',
                           border: '1px solid',
                           borderColor: 'orange.6',
                           borderRadius: 'l2',
                         })}>
-                          <span class={css({ fontSize: 'xs', color: 'orange.11', fontWeight: 'semibold' })}>🎯 Focus today:</span>
+                          <span class={css({ fontSize: 'xs', color: 'orange.11', fontWeight: 'semibold' })}>🎯 Weakest KC</span>
                           <span class={css({ fontSize: 'sm', fontWeight: 'medium', color: 'orange.11' })}>
                             {kc().labelPl ?? kc().label}
                             <Show when={kc().labelPl}>
                               <span class={css({ fontWeight: 'normal', ml: '1', color: 'orange.9' })}>({kc().label})</span>
                             </Show>
                           </span>
+                          <span class={css({ fontSize: 'xs', color: 'orange.10' })}>KC stability {formatStability(kc().currentStability)}</span>
+                          <DueStateBadge status={kc().dueStatus} dueIso={kc().currentDue} />
                         </div>
                       )}
                     </Show>
                   </div>
 
-                  {/* CTA */}
                   <div>
                     <A
-                      href={(() => {
-                        const wkc = data().weakestKC
-                        if (!wkc) return '/quiz'
-                        const params = new URLSearchParams({ kcId: wkc.id })
-                        if (wkc.label) params.set('kcLabel', wkc.label)
-                        if (wkc.labelPl) params.set('kcLabelPl', wkc.labelPl)
-                        return `/quiz?${params.toString()}`
-                      })()}
+                      href={weakest() ? buildFocusedSessionHref(weakest()!) : '/quiz'}
                       class={css({
                         display: 'inline-flex',
                         alignItems: 'center',
@@ -167,7 +450,7 @@ function SummaryBar() {
                         transition: 'background 0.15s',
                       })}
                     >
-                      ▶ Start focused session
+                      ▶ Practice weakest KC
                     </A>
                   </div>
                 </div>
@@ -181,7 +464,7 @@ function SummaryBar() {
 }
 
 function CaseMasterySection() {
-  const [cases, { refetch }] = createResource(() => api.analytics.kcMastery({ kind: 'case', sort: 'weakest' }))
+  const [cases, { refetch }] = createResource(() => api.analytics.kcMastery({ kind: 'case', sort: 'weakest' }) as Promise<KcItem[]>)
 
   return (
     <ErrorBoundary fallback={(err) => <ErrorState message={String(err)} onRetry={refetch} />}>
@@ -195,16 +478,9 @@ function CaseMasterySection() {
               </p>
             }
           >
-            <For each={cases()}>
-              {(kc: KcItem) => (
-                <MasteryBar
-                  labelPl={kc.labelPl}
-                  label={kc.label}
-                  masteredPct={kc.masteredPct}
-                  totalCards={kc.totalCards}
-                />
-              )}
-            </For>
+            <div class={css({ display: 'flex', flexDirection: 'column', gap: '2' })}>
+              <For each={cases()}>{(kc) => <KcRow kc={kc} />}</For>
+            </div>
           </Show>
         </Card>
       </Suspense>
@@ -215,16 +491,17 @@ function CaseMasterySection() {
 function DimensionSection(props: { kind: string; title: string }) {
   const [items, { refetch }] = createResource(
     () => props.kind,
-    (kind) => api.analytics.kcMastery({ kind: kind as 'number' | 'gender' | 'tense' | 'mood' | 'pos', sort: 'weakest' })
+    (kind) => api.analytics.kcMastery({ kind: kind as 'number' | 'gender' | 'tense' | 'mood' | 'pos', sort: 'weakest' }) as Promise<KcItem[]>,
   )
   const [open, setOpen] = createSignal(false)
+  const toggle = () => setOpen((value) => !value)
 
   return (
     <ErrorBoundary fallback={(err) => <ErrorState message={String(err)} onRetry={refetch} />}>
       <div class={css({ border: '1px solid', borderColor: 'border', borderRadius: 'l2', overflow: 'hidden' })}>
         <button
           type="button"
-          onClick={() => setOpen(v => !v)}
+          onClick={toggle}
           class={css({
             width: '100%',
             display: 'flex',
@@ -244,21 +521,14 @@ function DimensionSection(props: { kind: string; title: string }) {
         </button>
         <Show when={open()}>
           <Suspense fallback={<div class={css({ display: 'flex', justifyContent: 'center', py: '3' })}><Spinner /></div>}>
-            <div class={css({ px: '4', py: '2' })}>
+            <div class={css({ px: '4', py: '3' })}>
               <Show
                 when={(items() ?? []).length > 0}
                 fallback={<p class={css({ fontSize: 'sm', color: 'fg.muted', py: '2' })}>No data.</p>}
               >
-                <For each={items()}>
-                  {(kc: KcItem) => (
-                    <MasteryBar
-                      labelPl={kc.labelPl}
-                      label={kc.label}
-                      masteredPct={kc.masteredPct}
-                      totalCards={kc.totalCards}
-                    />
-                  )}
-                </For>
+                <div class={css({ display: 'flex', flexDirection: 'column', gap: '2' })}>
+                  <For each={items()}>{(kc) => <KcRow kc={kc} />}</For>
+                </div>
               </Show>
             </div>
           </Suspense>
@@ -269,12 +539,12 @@ function DimensionSection(props: { kind: string; title: string }) {
 }
 
 function LemmaProgressSection() {
-  const [lemmas, { refetch }] = createResource(() => api.analytics.kcMastery({ kind: 'lemma', sort: 'weakest', limit: 50 }))
+  const [lemmas, { refetch }] = createResource(() => api.analytics.kcMastery({ kind: 'lemma', sort: 'weakest', limit: 24 }) as Promise<KcItem[]>)
 
   return (
     <ErrorBoundary fallback={(err) => <ErrorState message={String(err)} onRetry={refetch} />}>
       <Suspense fallback={<div class={css({ display: 'flex', justifyContent: 'center', py: '4' })}><Spinner /></div>}>
-        <Card title="Lemma progress">
+        <Card title="Lemma FSRS state">
           <Show
             when={(lemmas() ?? []).length > 0}
             fallback={
@@ -283,31 +553,8 @@ function LemmaProgressSection() {
               </p>
             }
           >
-            <div class={css({ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '2' })}>
-              <For each={lemmas()}>
-                {(kc: KcItem) => {
-                  const emoji = kc.masteredPct >= 80 ? '🟢' : kc.masteredPct >= 40 ? '🟡' : '🔴'
-                  return (
-                    <div class={css({
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '2',
-                      px: '3',
-                      py: '2',
-                      bg: 'bg.subtle',
-                      borderRadius: 'l2',
-                      border: '1px solid',
-                      borderColor: 'border',
-                    })}>
-                      <span style={{ 'font-size': '14px' }}>{emoji}</span>
-                      <span class={css({ fontSize: 'sm', fontWeight: 'medium', color: 'fg.default', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
-                        {kc.labelPl ?? kc.label}
-                      </span>
-                      <span class={css({ fontSize: 'xs', color: 'fg.muted', flexShrink: 0 })}>{kc.masteredPct}%</span>
-                    </div>
-                  )
-                }}
-              </For>
+            <div class={css({ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '3' })}>
+              <For each={lemmas()}>{(kc) => <LemmaKcCard kc={kc} />}</For>
             </div>
           </Show>
         </Card>
@@ -319,24 +566,17 @@ function LemmaProgressSection() {
 export function KcDashboard() {
   return (
     <div class={css({ display: 'flex', flexDirection: 'column', gap: '6' })}>
-      {/* Summary bar */}
       <SummaryBar />
-
-      {/* Case mastery */}
       <CaseMasterySection />
 
-      {/* Dimensions — collapsible */}
       <Card title="Dimensions">
         <div class={css({ display: 'flex', flexDirection: 'column', gap: '2' })}>
           <For each={DIMENSION_KINDS}>
-            {(dim) => (
-              <DimensionSection kind={dim.kind} title={dim.label} />
-            )}
+            {(dim) => <DimensionSection kind={dim.kind} title={dim.label} />}
           </For>
         </div>
       </Card>
 
-      {/* Lemma progress */}
       <LemmaProgressSection />
     </div>
   )


### PR DESCRIPTION
## Summary
- extend KC analytics so the dashboard can show real current FSRS state, including KC due-status buckets and richer weakest-KC data
- refresh the KC dashboard UI with overdue/due-soon/comfortable indicators and focused practice launchers for structural and lemma KCs
- keep the scope honest: no trend charts or lemma trajectories, because the current schema does not persist historical KC stability snapshots

## Testing
- bun run --filter @rzyns/strus-db test
- bun run --filter @rzyns/strus-db typecheck
- bun run --filter @rzyns/strus-api test
- bun run --filter @rzyns/strus-api typecheck
- bun run --filter @rzyns/strus-web typecheck
